### PR TITLE
feat(database): implement CustomFieldDao and UserPreferencesDao (#66)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -11,11 +11,13 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 
+import 'package:swaralipi/core/database/daos/custom_field_dao.dart';
 import 'package:swaralipi/core/database/daos/instrument_dao.dart';
 import 'package:swaralipi/core/database/daos/notation_dao.dart';
 import 'package:swaralipi/core/database/daos/notation_page_dao.dart';
 import 'package:swaralipi/core/database/daos/notation_tag_dao.dart';
 import 'package:swaralipi/core/database/daos/tag_dao.dart';
+import 'package:swaralipi/core/database/daos/user_preferences_dao.dart';
 
 part 'app_database.g.dart';
 
@@ -383,6 +385,8 @@ class UserPreferencesTable extends Table {
     TagDao,
     NotationTagDao,
     InstrumentDao,
+    CustomFieldDao,
+    UserPreferencesDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3775,6 +3775,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final NotationTagDao notationTagDao =
       NotationTagDao(this as AppDatabase);
   late final InstrumentDao instrumentDao = InstrumentDao(this as AppDatabase);
+  late final CustomFieldDao customFieldDao =
+      CustomFieldDao(this as AppDatabase);
+  late final UserPreferencesDao userPreferencesDao =
+      UserPreferencesDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();

--- a/lib/core/database/daos/custom_field_dao.dart
+++ b/lib/core/database/daos/custom_field_dao.dart
@@ -1,0 +1,245 @@
+// CustomFieldDao — Drift DAO for the custom_field_definitions and
+// notation_custom_fields tables.
+//
+// Exposes all CRUD and value-write operations required by the
+// CustomFieldRepository. All queries use Drift's type-safe query DSL; no raw
+// SQL strings are used anywhere in this file.
+//
+// Register this class in AppDatabase's @DriftDatabase(daos: [...]) annotation
+// and call `CustomFieldDao(db)` to construct an instance.
+
+import 'dart:developer';
+
+import 'package:drift/drift.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+
+part 'custom_field_dao.g.dart';
+
+/// Data-access object for the [CustomFieldDefinitionsTable] and
+/// [NotationCustomFieldsTable].
+///
+/// Manages custom field definitions (insert, update, delete, list) and their
+/// per-notation values via [setCustomFieldValue] and [getValuesForNotation].
+/// Sparse column writes are enforced here: only the column matching
+/// [fieldType] is populated; all others remain NULL.
+///
+/// Business logic and domain-model translation belong in the repository layer,
+/// not here.
+@DriftAccessor(
+  tables: [CustomFieldDefinitionsTable, NotationCustomFieldsTable],
+)
+class CustomFieldDao extends DatabaseAccessor<AppDatabase>
+    with _$CustomFieldDaoMixin {
+  /// Creates a [CustomFieldDao] attached to [db].
+  CustomFieldDao(super.db);
+
+  // -------------------------------------------------------------------------
+  // Definition write operations
+  // -------------------------------------------------------------------------
+
+  /// Inserts a new custom field definition row.
+  ///
+  /// Throws if [companion.id] already exists (primary-key violation) or if
+  /// [companion.keyName] already exists (UNIQUE constraint on key_name).
+  ///
+  /// Parameters:
+  /// - [companion]: A fully populated
+  ///   [CustomFieldDefinitionsTableCompanion].
+  Future<void> insertDefinition(
+    CustomFieldDefinitionsTableCompanion companion,
+  ) async {
+    await into(customFieldDefinitionsTable).insert(companion);
+    log(
+      'CustomFieldDao: inserted definition ${companion.id.value}',
+      name: 'CustomFieldDao',
+    );
+  }
+
+  /// Updates an existing custom field definition row.
+  ///
+  /// Only columns present as [Value] (not [Value.absent()]) are written.
+  /// Returns `true` if the row was found and updated, `false` otherwise.
+  ///
+  /// Parameters:
+  /// - [companion]: A partial [CustomFieldDefinitionsTableCompanion] with
+  ///   [companion.id] set to identify the target row.
+  Future<bool> updateDefinition(
+    CustomFieldDefinitionsTableCompanion companion,
+  ) async {
+    final rowsAffected = await (update(customFieldDefinitionsTable)
+          ..where((t) => t.id.equals(companion.id.value)))
+        .write(companion);
+    return rowsAffected > 0;
+  }
+
+  /// Permanently deletes the definition row with [id].
+  ///
+  /// All associated [NotationCustomFieldsTable] rows cascade-delete
+  /// automatically via the `ON DELETE CASCADE` foreign key constraint. If no
+  /// row matches [id], the call is silently ignored.
+  ///
+  /// Parameters:
+  /// - [id]: The UUIDv4 primary key of the definition to delete.
+  Future<void> deleteDefinition(String id) async {
+    await (delete(customFieldDefinitionsTable)..where((t) => t.id.equals(id)))
+        .go();
+    log('CustomFieldDao: deleted definition $id', name: 'CustomFieldDao');
+  }
+
+  // -------------------------------------------------------------------------
+  // Definition read operations
+  // -------------------------------------------------------------------------
+
+  /// Returns all custom field definition rows, ordered by
+  /// [CustomFieldDefinitionsTable.keyName] ascending.
+  Future<List<CustomFieldDefinitionRow>> getAllDefinitions() {
+    return (select(customFieldDefinitionsTable)
+          ..orderBy([(t) => OrderingTerm.asc(t.keyName)]))
+        .get();
+  }
+
+  /// Emits a live list of all custom field definition rows, ordered by
+  /// [CustomFieldDefinitionsTable.keyName] ascending.
+  ///
+  /// The stream re-emits whenever the underlying table changes.
+  Stream<List<CustomFieldDefinitionRow>> watchAllDefinitions() {
+    return (select(customFieldDefinitionsTable)
+          ..orderBy([(t) => OrderingTerm.asc(t.keyName)]))
+        .watch();
+  }
+
+  // -------------------------------------------------------------------------
+  // Value write operations
+  // -------------------------------------------------------------------------
+
+  /// Inserts or replaces the custom field value for the given notation and
+  /// definition pair.
+  ///
+  /// Enforces the sparse column contract: only the value column matching
+  /// [fieldType] is populated; all other value columns are set to NULL. This
+  /// prevents cross-type pollution as required by data-model.md §2.9.
+  ///
+  /// Throws [ArgumentError] if [fieldType] is not one of `'text'`, `'number'`,
+  /// `'date'`, or `'boolean'`.
+  ///
+  /// Parameters:
+  /// - [notationId]: FK to the parent [NotationsTable] row.
+  /// - [definitionId]: FK to the [CustomFieldDefinitionsTable] row.
+  /// - [fieldType]: One of `'text'`, `'number'`, `'date'`, `'boolean'`.
+  /// - [textValue]: Value to store when [fieldType] is `'text'`.
+  /// - [numberValue]: Value to store when [fieldType] is `'number'`.
+  /// - [dateValue]: ISO 8601 date string when [fieldType] is `'date'`.
+  /// - [booleanValue]: Boolean value when [fieldType] is `'boolean'`.
+  Future<void> setCustomFieldValue({
+    required String notationId,
+    required String definitionId,
+    required String fieldType,
+    String? textValue,
+    double? numberValue,
+    String? dateValue,
+    bool? booleanValue,
+  }) async {
+    final companion = _buildValueCompanion(
+      notationId: notationId,
+      definitionId: definitionId,
+      fieldType: fieldType,
+      textValue: textValue,
+      numberValue: numberValue,
+      dateValue: dateValue,
+      booleanValue: booleanValue,
+    );
+    await into(notationCustomFieldsTable).insertOnConflictUpdate(companion);
+    log(
+      'CustomFieldDao: set value for notation=$notationId '
+      'definition=$definitionId type=$fieldType',
+      name: 'CustomFieldDao',
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Value read operations
+  // -------------------------------------------------------------------------
+
+  /// Returns all custom field value rows for [notationId].
+  ///
+  /// Returns an empty list when no values have been set for the notation.
+  ///
+  /// Parameters:
+  /// - [notationId]: FK to the parent [NotationsTable] row.
+  Future<List<NotationCustomFieldRow>> getValuesForNotation(
+    String notationId,
+  ) {
+    return (select(notationCustomFieldsTable)
+          ..where((t) => t.notationId.equals(notationId)))
+        .get();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /// Builds a [NotationCustomFieldsTableCompanion] with sparse column
+  /// population based on [fieldType].
+  ///
+  /// Only the value column matching [fieldType] receives a [Value]; all
+  /// others are explicitly set to [Value(null)] to clear stale data on upsert.
+  ///
+  /// Parameters:
+  /// - [notationId]: FK to the parent [NotationsTable] row.
+  /// - [definitionId]: FK to the [CustomFieldDefinitionsTable] row.
+  /// - [fieldType]: One of `'text'`, `'number'`, `'date'`, `'boolean'`.
+  /// - [textValue]: Value used when [fieldType] is `'text'`.
+  /// - [numberValue]: Value used when [fieldType] is `'number'`.
+  /// - [dateValue]: Value used when [fieldType] is `'date'`.
+  /// - [booleanValue]: Value used when [fieldType] is `'boolean'`.
+  NotationCustomFieldsTableCompanion _buildValueCompanion({
+    required String notationId,
+    required String definitionId,
+    required String fieldType,
+    String? textValue,
+    double? numberValue,
+    String? dateValue,
+    bool? booleanValue,
+  }) {
+    return switch (fieldType) {
+      'text' => NotationCustomFieldsTableCompanion.insert(
+          notationId: notationId,
+          definitionId: definitionId,
+          valueText: Value(textValue),
+          valueNumber: const Value(null),
+          valueDate: const Value(null),
+          valueBoolean: const Value(null),
+        ),
+      'number' => NotationCustomFieldsTableCompanion.insert(
+          notationId: notationId,
+          definitionId: definitionId,
+          valueText: const Value(null),
+          valueNumber: Value(numberValue),
+          valueDate: const Value(null),
+          valueBoolean: const Value(null),
+        ),
+      'date' => NotationCustomFieldsTableCompanion.insert(
+          notationId: notationId,
+          definitionId: definitionId,
+          valueText: const Value(null),
+          valueNumber: const Value(null),
+          valueDate: Value(dateValue),
+          valueBoolean: const Value(null),
+        ),
+      'boolean' => NotationCustomFieldsTableCompanion.insert(
+          notationId: notationId,
+          definitionId: definitionId,
+          valueText: const Value(null),
+          valueNumber: const Value(null),
+          valueDate: const Value(null),
+          valueBoolean:
+              Value(booleanValue == null ? null : (booleanValue ? 1 : 0)),
+        ),
+      _ => throw ArgumentError(
+          'Unknown fieldType "$fieldType". '
+          "Must be one of 'text', 'number', 'date', 'boolean'.",
+        ),
+    };
+  }
+}

--- a/lib/core/database/daos/custom_field_dao.g.dart
+++ b/lib/core/database/daos/custom_field_dao.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'custom_field_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$CustomFieldDaoMixin on DatabaseAccessor<AppDatabase> {
+  $CustomFieldDefinitionsTableTable get customFieldDefinitionsTable =>
+      attachedDatabase.customFieldDefinitionsTable;
+  $NotationsTableTable get notationsTable => attachedDatabase.notationsTable;
+  $NotationCustomFieldsTableTable get notationCustomFieldsTable =>
+      attachedDatabase.notationCustomFieldsTable;
+  CustomFieldDaoManager get managers => CustomFieldDaoManager(this);
+}
+
+class CustomFieldDaoManager {
+  final _$CustomFieldDaoMixin _db;
+  CustomFieldDaoManager(this._db);
+  $$CustomFieldDefinitionsTableTableTableManager
+      get customFieldDefinitionsTable =>
+          $$CustomFieldDefinitionsTableTableTableManager(
+              _db.attachedDatabase, _db.customFieldDefinitionsTable);
+  $$NotationsTableTableTableManager get notationsTable =>
+      $$NotationsTableTableTableManager(
+          _db.attachedDatabase, _db.notationsTable);
+  $$NotationCustomFieldsTableTableTableManager get notationCustomFieldsTable =>
+      $$NotationCustomFieldsTableTableTableManager(
+          _db.attachedDatabase, _db.notationCustomFieldsTable);
+}

--- a/lib/core/database/daos/user_preferences_dao.dart
+++ b/lib/core/database/daos/user_preferences_dao.dart
@@ -1,0 +1,111 @@
+// UserPreferencesDao — Drift DAO for the user_preferences table.
+//
+// Exposes the singleton read (getPreferences) and upsert (upsertPreferences)
+// operations required by the PreferencesRepository. All queries use Drift's
+// type-safe query DSL; no raw SQL strings are used anywhere in this file.
+//
+// The `id = 1` singleton constraint is enforced at the DB level via a CHECK
+// constraint. This DAO additionally creates the default row on first read so
+// callers never receive null.
+//
+// Register this class in AppDatabase's @DriftDatabase(daos: [...]) annotation
+// and call `UserPreferencesDao(db)` to construct an instance.
+
+import 'dart:developer';
+
+import 'package:drift/drift.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+
+part 'user_preferences_dao.g.dart';
+
+/// Data-access object for the [UserPreferencesTable].
+///
+/// Manages the singleton user preferences row. [getPreferences] creates the
+/// default row on first access so callers always receive a non-null value.
+/// [upsertPreferences] replaces the singleton row, merging only the fields
+/// present in the companion.
+///
+/// Business logic and domain-model translation belong in the repository layer,
+/// not here.
+@DriftAccessor(tables: [UserPreferencesTable])
+class UserPreferencesDao extends DatabaseAccessor<AppDatabase>
+    with _$UserPreferencesDaoMixin {
+  /// Creates a [UserPreferencesDao] attached to [db].
+  UserPreferencesDao(super.db);
+
+  // -------------------------------------------------------------------------
+  // Read operations
+  // -------------------------------------------------------------------------
+
+  /// Returns the singleton user preferences row.
+  ///
+  /// If the row does not yet exist (first launch before seed migration), a
+  /// default row is inserted and then returned. The returned row always has
+  /// `id = 1`.
+  Future<UserPreferencesRow> getPreferences() async {
+    final existing = await (select(userPreferencesTable)
+          ..where((t) => t.id.equals(_kSingletonId)))
+        .getSingleOrNull();
+
+    if (existing != null) {
+      return existing;
+    }
+
+    // First access: insert the default singleton row and return it.
+    await into(userPreferencesTable).insert(
+      const UserPreferencesTableCompanion(),
+    );
+    log(
+      'UserPreferencesDao: created default preferences row',
+      name: 'UserPreferencesDao',
+    );
+    return (select(userPreferencesTable)
+          ..where((t) => t.id.equals(_kSingletonId)))
+        .getSingle();
+  }
+
+  // -------------------------------------------------------------------------
+  // Write operations
+  // -------------------------------------------------------------------------
+
+  /// Inserts or updates the singleton user preferences row.
+  ///
+  /// If the row with `id = 1` does not yet exist it is inserted with the
+  /// column defaults merged with [companion]. If it already exists, only the
+  /// non-absent columns in [companion] are overwritten; all other columns
+  /// retain their current database values.
+  ///
+  /// Parameters:
+  /// - [companion]: A [UserPreferencesTableCompanion] with the fields to
+  ///   persist. Omitted fields default to the column default values on insert
+  ///   or are left unchanged on update.
+  Future<void> upsertPreferences(
+    UserPreferencesTableCompanion companion,
+  ) async {
+    final existing = await (select(userPreferencesTable)
+          ..where((t) => t.id.equals(_kSingletonId)))
+        .getSingleOrNull();
+
+    if (existing == null) {
+      await into(userPreferencesTable).insert(companion);
+    } else {
+      await (update(userPreferencesTable)
+            ..where((t) => t.id.equals(_kSingletonId)))
+          .write(companion);
+    }
+    log(
+      'UserPreferencesDao: upserted preferences',
+      name: 'UserPreferencesDao',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// The fixed primary-key value for the singleton user preferences row.
+///
+/// Enforced at the database level via `CHECK (id = 1)`.
+const int _kSingletonId = 1;

--- a/lib/core/database/daos/user_preferences_dao.g.dart
+++ b/lib/core/database/daos/user_preferences_dao.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_preferences_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$UserPreferencesDaoMixin on DatabaseAccessor<AppDatabase> {
+  $UserPreferencesTableTable get userPreferencesTable =>
+      attachedDatabase.userPreferencesTable;
+  UserPreferencesDaoManager get managers => UserPreferencesDaoManager(this);
+}
+
+class UserPreferencesDaoManager {
+  final _$UserPreferencesDaoMixin _db;
+  UserPreferencesDaoManager(this._db);
+  $$UserPreferencesTableTableTableManager get userPreferencesTable =>
+      $$UserPreferencesTableTableTableManager(
+          _db.attachedDatabase, _db.userPreferencesTable);
+}

--- a/test/unit/core/database/daos/custom_field_dao_test.dart
+++ b/test/unit/core/database/daos/custom_field_dao_test.dart
@@ -1,0 +1,554 @@
+// Unit tests for CustomFieldDao.
+//
+// Covers all public methods against an in-memory Drift database:
+//   insertDefinition, updateDefinition, deleteDefinition,
+//   getAllDefinitions, watchAllDefinitions,
+//   setCustomFieldValue, getValuesForNotation.
+//
+// Each test group sets up a fresh AppDatabase.forTesting() in setUp and
+// closes it in tearDown, ensuring full isolation between test cases.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/database/daos/custom_field_dao.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns an ISO 8601 UTC datetime string for test fixtures.
+String _ts(String suffix) => '2024-01-01T${suffix}Z';
+
+/// Inserts a minimal notation row required for FK constraints.
+Future<void> _insertNotation(AppDatabase db, String id) async {
+  await db.into(db.notationsTable).insert(
+        NotationsTableCompanion.insert(
+          id: id,
+          title: 'Test Notation $id',
+          createdAt: _ts('09:00:00'),
+          updatedAt: _ts('09:00:00'),
+        ),
+      );
+}
+
+/// Inserts a custom field definition and returns its id.
+Future<String> _insertDefinition(
+  AppDatabase db, {
+  required String id,
+  String keyName = 'tempo',
+  String fieldType = 'number',
+}) async {
+  await db.into(db.customFieldDefinitionsTable).insert(
+        CustomFieldDefinitionsTableCompanion.insert(
+          id: id,
+          keyName: keyName,
+          fieldType: fieldType,
+          createdAt: _ts('10:00:00'),
+          updatedAt: _ts('10:00:00'),
+        ),
+      );
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // -------------------------------------------------------------------------
+  // insertDefinition
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.insertDefinition', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+    });
+    tearDown(() => db.close());
+
+    test('inserts a definition and it is retrievable via select', () async {
+      final companion = CustomFieldDefinitionsTableCompanion.insert(
+        id: 'def1',
+        keyName: 'tempo',
+        fieldType: 'number',
+        createdAt: _ts('09:00:00'),
+        updatedAt: _ts('09:00:00'),
+      );
+
+      await dao.insertDefinition(companion);
+
+      final rows = await db.select(db.customFieldDefinitionsTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.id, 'def1');
+      expect(rows.first.keyName, 'tempo');
+      expect(rows.first.fieldType, 'number');
+    });
+
+    test('duplicate id throws', () async {
+      final companion = CustomFieldDefinitionsTableCompanion.insert(
+        id: 'def-dup',
+        keyName: 'key1',
+        fieldType: 'text',
+        createdAt: _ts('09:00:00'),
+        updatedAt: _ts('09:00:00'),
+      );
+      await dao.insertDefinition(companion);
+
+      expect(
+        () => dao.insertDefinition(companion),
+        throwsA(anything),
+      );
+    });
+
+    test('duplicate keyName throws due to UNIQUE constraint', () async {
+      await dao.insertDefinition(
+        CustomFieldDefinitionsTableCompanion.insert(
+          id: 'def1',
+          keyName: 'unique_key',
+          fieldType: 'text',
+          createdAt: _ts('09:00:00'),
+          updatedAt: _ts('09:00:00'),
+        ),
+      );
+
+      expect(
+        () => dao.insertDefinition(
+          CustomFieldDefinitionsTableCompanion.insert(
+            id: 'def2',
+            keyName: 'unique_key',
+            fieldType: 'boolean',
+            createdAt: _ts('09:00:00'),
+            updatedAt: _ts('09:00:00'),
+          ),
+        ),
+        throwsA(anything),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // updateDefinition
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.updateDefinition', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertDefinition(db, id: 'def1', keyName: 'original_key');
+    });
+    tearDown(() => db.close());
+
+    test('updates keyName and returns true', () async {
+      final companion = CustomFieldDefinitionsTableCompanion(
+        id: const Value('def1'),
+        keyName: const Value('updated_key'),
+        updatedAt: Value(_ts('11:00:00')),
+      );
+
+      final updated = await dao.updateDefinition(companion);
+
+      expect(updated, isTrue);
+      final row = await (db.select(db.customFieldDefinitionsTable)
+            ..where((t) => t.id.equals('def1')))
+          .getSingle();
+      expect(row.keyName, 'updated_key');
+    });
+
+    test('returns false for a non-existent id', () async {
+      final companion = CustomFieldDefinitionsTableCompanion(
+        id: const Value('ghost'),
+        keyName: const Value('noop'),
+        updatedAt: Value(_ts('11:00:00')),
+      );
+
+      final updated = await dao.updateDefinition(companion);
+      expect(updated, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteDefinition
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.deleteDefinition', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertDefinition(db, id: 'def1');
+    });
+    tearDown(() => db.close());
+
+    test('permanently removes a definition row', () async {
+      await dao.deleteDefinition('def1');
+
+      final rows = await db.select(db.customFieldDefinitionsTable).get();
+      expect(rows, isEmpty);
+    });
+
+    test('is a no-op for a non-existent id', () async {
+      // Must not throw.
+      await dao.deleteDefinition('ghost');
+    });
+
+    test('cascades and removes associated notation_custom_fields rows',
+        () async {
+      await _insertNotation(db, 'n1');
+      // Insert a value linked to def1.
+      await db.into(db.notationCustomFieldsTable).insert(
+            NotationCustomFieldsTableCompanion.insert(
+              notationId: 'n1',
+              definitionId: 'def1',
+              valueNumber: const Value(120.0),
+            ),
+          );
+
+      await dao.deleteDefinition('def1');
+
+      final values = await db.select(db.notationCustomFieldsTable).get();
+      expect(values, isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAllDefinitions
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.getAllDefinitions', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+    });
+    tearDown(() => db.close());
+
+    test('returns empty list when no definitions exist', () async {
+      final defs = await dao.getAllDefinitions();
+      expect(defs, isEmpty);
+    });
+
+    test('returns all inserted definitions ordered by keyName', () async {
+      await _insertDefinition(db, id: 'def2', keyName: 'zebra');
+      await _insertDefinition(db, id: 'def1', keyName: 'alpha');
+
+      final defs = await dao.getAllDefinitions();
+      expect(defs, hasLength(2));
+      expect(defs.map((d) => d.keyName).toList(), ['alpha', 'zebra']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // watchAllDefinitions
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.watchAllDefinitions', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+    });
+    tearDown(() => db.close());
+
+    test('emits empty list when no definitions exist', () async {
+      final rows = await dao.watchAllDefinitions().first;
+      expect(rows, isEmpty);
+    });
+
+    test('emits definitions ordered by keyName', () async {
+      await _insertDefinition(db, id: 'def2', keyName: 'zebra');
+      await _insertDefinition(db, id: 'def1', keyName: 'alpha');
+
+      final rows = await dao.watchAllDefinitions().first;
+      expect(rows.map((r) => r.keyName).toList(), ['alpha', 'zebra']);
+    });
+
+    test('stream emits updated list after a new definition is inserted',
+        () async {
+      expect(await dao.watchAllDefinitions().first, isEmpty);
+
+      await _insertDefinition(db, id: 'def1', keyName: 'tempo');
+
+      final rows = await dao.watchAllDefinitions().first;
+      expect(rows, hasLength(1));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setCustomFieldValue
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.setCustomFieldValue — text', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertDefinition(
+        db,
+        id: 'def-text',
+        keyName: 'lyrics',
+        fieldType: 'text',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('inserts a text value with only value_text populated', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-text',
+        fieldType: 'text',
+        textValue: 'Sa Re Ga Ma',
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.valueText, 'Sa Re Ga Ma');
+      expect(rows.first.valueNumber, isNull);
+      expect(rows.first.valueDate, isNull);
+      expect(rows.first.valueBoolean, isNull);
+    });
+
+    test('upserts existing value when called again', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-text',
+        fieldType: 'text',
+        textValue: 'first',
+      );
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-text',
+        fieldType: 'text',
+        textValue: 'second',
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.valueText, 'second');
+    });
+  });
+
+  group('CustomFieldDao.setCustomFieldValue — number', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertDefinition(
+        db,
+        id: 'def-num',
+        keyName: 'tempo',
+        fieldType: 'number',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('inserts a number value with only value_number populated', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-num',
+        fieldType: 'number',
+        numberValue: 120.5,
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows.first.valueNumber, 120.5);
+      expect(rows.first.valueText, isNull);
+      expect(rows.first.valueDate, isNull);
+      expect(rows.first.valueBoolean, isNull);
+    });
+  });
+
+  group('CustomFieldDao.setCustomFieldValue — date', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertDefinition(
+        db,
+        id: 'def-date',
+        keyName: 'recorded_on',
+        fieldType: 'date',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('inserts a date value with only value_date populated', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-date',
+        fieldType: 'date',
+        dateValue: '2024-06-15',
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows.first.valueDate, '2024-06-15');
+      expect(rows.first.valueText, isNull);
+      expect(rows.first.valueNumber, isNull);
+      expect(rows.first.valueBoolean, isNull);
+    });
+  });
+
+  group('CustomFieldDao.setCustomFieldValue — boolean', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertDefinition(
+        db,
+        id: 'def-bool',
+        keyName: 'is_favorite',
+        fieldType: 'boolean',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('inserts a boolean true value with only value_boolean populated',
+        () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-bool',
+        fieldType: 'boolean',
+        booleanValue: true,
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows.first.valueBoolean, 1);
+      expect(rows.first.valueText, isNull);
+      expect(rows.first.valueNumber, isNull);
+      expect(rows.first.valueDate, isNull);
+    });
+
+    test('inserts a boolean false value as 0', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def-bool',
+        fieldType: 'boolean',
+        booleanValue: false,
+      );
+
+      final rows = await db.select(db.notationCustomFieldsTable).get();
+      expect(rows.first.valueBoolean, 0);
+    });
+  });
+
+  group('CustomFieldDao.setCustomFieldValue — invalid fieldType', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertDefinition(
+        db,
+        id: 'def1',
+        keyName: 'tempo',
+        fieldType: 'number',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('throws ArgumentError for unknown fieldType', () async {
+      expect(
+        () => dao.setCustomFieldValue(
+          notationId: 'n1',
+          definitionId: 'def1',
+          fieldType: 'unknown',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getValuesForNotation
+  // -------------------------------------------------------------------------
+
+  group('CustomFieldDao.getValuesForNotation', () {
+    late AppDatabase db;
+    late CustomFieldDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = CustomFieldDao(db);
+      await _insertNotation(db, 'n1');
+      await _insertNotation(db, 'n2');
+      await _insertDefinition(db, id: 'def1', keyName: 'tempo');
+      await _insertDefinition(
+        db,
+        id: 'def2',
+        keyName: 'lyrics',
+        fieldType: 'text',
+      );
+    });
+    tearDown(() => db.close());
+
+    test('returns empty list when no values exist for notation', () async {
+      final values = await dao.getValuesForNotation('n1');
+      expect(values, isEmpty);
+    });
+
+    test('returns only values for the requested notation', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def1',
+        fieldType: 'number',
+        numberValue: 100.0,
+      );
+      await dao.setCustomFieldValue(
+        notationId: 'n2',
+        definitionId: 'def1',
+        fieldType: 'number',
+        numberValue: 200.0,
+      );
+
+      final values = await dao.getValuesForNotation('n1');
+      expect(values, hasLength(1));
+      expect(values.first.notationId, 'n1');
+      expect(values.first.valueNumber, 100.0);
+    });
+
+    test('returns multiple values for different definitions', () async {
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def1',
+        fieldType: 'number',
+        numberValue: 80.0,
+      );
+      await dao.setCustomFieldValue(
+        notationId: 'n1',
+        definitionId: 'def2',
+        fieldType: 'text',
+        textValue: 'Sa Pa',
+      );
+
+      final values = await dao.getValuesForNotation('n1');
+      expect(values, hasLength(2));
+    });
+  });
+}

--- a/test/unit/core/database/daos/user_preferences_dao_test.dart
+++ b/test/unit/core/database/daos/user_preferences_dao_test.dart
@@ -1,0 +1,237 @@
+// Unit tests for UserPreferencesDao.
+//
+// Covers all public methods against an in-memory Drift database:
+//   getPreferences, upsertPreferences.
+//
+// Each test group sets up a fresh AppDatabase.forTesting() in setUp and
+// closes it in tearDown, ensuring full isolation between test cases.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/database/daos/user_preferences_dao.dart';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // -------------------------------------------------------------------------
+  // getPreferences
+  // -------------------------------------------------------------------------
+
+  group('UserPreferencesDao.getPreferences', () {
+    late AppDatabase db;
+    late UserPreferencesDao dao;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      dao = UserPreferencesDao(db);
+    });
+    tearDown(() => db.close());
+
+    test('returns default row when table is empty', () async {
+      final prefs = await dao.getPreferences();
+
+      expect(prefs, isNotNull);
+      expect(prefs.id, 1);
+      expect(prefs.userName, 'Musician');
+      expect(prefs.themeMode, 'system');
+      expect(prefs.colorSchemeMode, 'catppuccin');
+      expect(prefs.seedColor, isNull);
+      expect(prefs.defaultSort, 'created_at_desc');
+      expect(prefs.defaultView, 'list');
+    });
+
+    test('returns existing row when one is already present', () async {
+      // Pre-insert a row with custom values.
+      await db.into(db.userPreferencesTable).insert(
+            const UserPreferencesTableCompanion(),
+          );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.id, 1);
+      expect(prefs.userName, 'Musician');
+    });
+
+    test('calling getPreferences twice returns the same row', () async {
+      final first = await dao.getPreferences();
+      final second = await dao.getPreferences();
+
+      expect(first.id, second.id);
+      expect(first.userName, second.userName);
+    });
+
+    test('singleton row always has id = 1', () async {
+      final prefs = await dao.getPreferences();
+      expect(prefs.id, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // upsertPreferences
+  // -------------------------------------------------------------------------
+
+  group('UserPreferencesDao.upsertPreferences — insert path', () {
+    late AppDatabase db;
+    late UserPreferencesDao dao;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      dao = UserPreferencesDao(db);
+    });
+    tearDown(() => db.close());
+
+    test('inserts preferences when table is empty', () async {
+      const companion = UserPreferencesTableCompanion();
+      await dao.upsertPreferences(companion);
+
+      final rows = await db.select(db.userPreferencesTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.id, 1);
+    });
+
+    test('persists non-default userName', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          userName: Value('Roudranil'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.userName, 'Roudranil');
+    });
+
+    test('persists dark themeMode', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          themeMode: Value('dark'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.themeMode, 'dark');
+    });
+
+    test('persists monet colorSchemeMode', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          colorSchemeMode: Value('monet'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.colorSchemeMode, 'monet');
+    });
+
+    test('persists a seedColor hex', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          seedColor: Value('#cba6f7'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.seedColor, '#cba6f7');
+    });
+
+    test('persists a non-default defaultSort', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          defaultSort: Value('title_asc'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.defaultSort, 'title_asc');
+    });
+  });
+
+  group('UserPreferencesDao.upsertPreferences — update path', () {
+    late AppDatabase db;
+    late UserPreferencesDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = UserPreferencesDao(db);
+      // Seed the singleton row.
+      await dao.upsertPreferences(const UserPreferencesTableCompanion());
+    });
+    tearDown(() => db.close());
+
+    test('updates userName without creating a duplicate row', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          userName: Value('New Name'),
+        ),
+      );
+
+      final rows = await db.select(db.userPreferencesTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.userName, 'New Name');
+    });
+
+    test('updates themeMode to light', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          themeMode: Value('light'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.themeMode, 'light');
+    });
+
+    test('updates multiple fields in one call', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          userName: Value('Raaga'),
+          themeMode: Value('dark'),
+          colorSchemeMode: Value('monet'),
+          defaultSort: Value('play_count_desc'),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.userName, 'Raaga');
+      expect(prefs.themeMode, 'dark');
+      expect(prefs.colorSchemeMode, 'monet');
+      expect(prefs.defaultSort, 'play_count_desc');
+    });
+
+    test('clears seedColor when set to null', () async {
+      // First set a seed color.
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          seedColor: Value('#f38ba8'),
+        ),
+      );
+      // Now clear it.
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(
+          seedColor: Value(null),
+        ),
+      );
+
+      final prefs = await dao.getPreferences();
+      expect(prefs.seedColor, isNull);
+    });
+
+    test('table still has exactly one row after multiple upserts', () async {
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(userName: Value('A')),
+      );
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(userName: Value('B')),
+      );
+      await dao.upsertPreferences(
+        const UserPreferencesTableCompanion(userName: Value('C')),
+      );
+
+      final rows = await db.select(db.userPreferencesTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.userName, 'C');
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Closes #66

## Summary
- Implements `CustomFieldDao` for `custom_field_definitions` and `notation_custom_fields` tables — insertDefinition, updateDefinition, deleteDefinition (cascade), getAllDefinitions, watchAllDefinitions, setCustomFieldValue, getValuesForNotation.
- Implements `UserPreferencesDao` for the `user_preferences` singleton — getPreferences (auto-creates default row on first access), upsertPreferences (explicit check-then-insert/update to avoid empty SET clause with all-default companions).
- Enforces sparse column contract in `setCustomFieldValue` via exhaustive switch on `fieldType`; throws `ArgumentError` for unknown types.
- Registers both DAOs in `AppDatabase @DriftDatabase(daos: [...])`.

## Type of Change
- [x] feat — new capability
- [ ] fix — bug fix
- [ ] refactor — no behavior change
- [ ] test — tests only
- [ ] docs — documentation only
- [ ] chore — build / tooling / deps
- [ ] ci — CI/CD changes

## Commit Convention
`feat(database): implement CustomFieldDao and UserPreferencesDao (#66)`

## Test Plan
- [x] Unit tests written / updated
  - `test/unit/core/database/daos/custom_field_dao_test.dart` — 23 tests
  - `test/unit/core/database/daos/user_preferences_dao_test.dart` — 15 tests
- [x] `flutter test --coverage` passes locally (271/271 tests pass)
- [x] Coverage ≥ 80% on new files
- [x] `flutter analyze` — zero warnings
- [x] `dart format` applied

## Checklist
- [x] No `print` statements (use `dart:developer` `log`)
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] Generated files committed (`.g.dart`)
- [x] No hardcoded secrets