### PR TITLE
feat(database): implement FTS5 virtual table, triggers, and FtsDao (#67)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -12,6 +12,7 @@ import 'package:drift/native.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 
 import 'package:swaralipi/core/database/daos/custom_field_dao.dart';
+import 'package:swaralipi/core/database/daos/fts_dao.dart';
 import 'package:swaralipi/core/database/daos/instrument_dao.dart';
 import 'package:swaralipi/core/database/daos/notation_dao.dart';
 import 'package:swaralipi/core/database/daos/notation_page_dao.dart';
@@ -387,6 +388,7 @@ class UserPreferencesTable extends Table {
     InstrumentDao,
     CustomFieldDao,
     UserPreferencesDao,
+    FtsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -403,6 +405,10 @@ class AppDatabase extends _$AppDatabase {
   /// Used exclusively in unit tests. Foreign keys are enabled via the
   /// [DatabaseSetup] callback. Seed data is skipped so each test starts with
   /// an empty, predictable schema.
+  ///
+  /// After constructing a test database, callers that require FTS5 search
+  /// must call [createFtsSchema] once after the first query to set up the
+  /// virtual table and triggers on the fully-open connection.
   AppDatabase.forTesting()
       : _seedOnCreate = false,
         super(
@@ -422,7 +428,84 @@ class AppDatabase extends _$AppDatabase {
             await _seedInitialData();
           }
         },
+        beforeOpen: (details) async {
+          // FTS schema is created here for the production (file-based) database.
+          // Test databases created with [AppDatabase.forTesting] must call
+          // [createFtsSchema] explicitly from test setUp after opening, because
+          // Drift's BeforeOpenRunner zone prevents DDL for virtual tables from
+          // executing on NativeDatabase.memory connections.
+          if (details.wasCreated && _seedOnCreate) {
+            await createFtsSchema();
+          }
+        },
       );
+
+  /// Creates the FTS5 virtual table and sync triggers on the open connection.
+  ///
+  /// Called automatically from [MigrationStrategy.onCreate] in production.
+  /// Tests that use [AppDatabase.forTesting] and require FTS search must call
+  /// this method once after opening the database (after the first query that
+  /// triggers schema creation), because Drift's [BeforeOpenRunner] zone
+  /// prevents DDL statements for virtual tables from running inside
+  /// [MigrationStrategy.onCreate] on in-memory [NativeDatabase.memory]
+  /// connections.
+  ///
+  /// The method is idempotent — it uses `IF NOT EXISTS` guards on all
+  /// statements and is safe to call multiple times.
+  Future<void> createFtsSchema() async {
+    // Drift generates the SQLite table name as 'notations_table' (not
+    // 'notations') for the NotationsTable class. All FTS5 DDL uses this name.
+    await customStatement(
+      'CREATE VIRTUAL TABLE IF NOT EXISTS notations_fts'
+      ' USING fts5('
+      'title, artists, notes,'
+      " content='notations_table',"
+      " content_rowid='rowid',"
+      " tokenize='unicode61'"
+      ')',
+    );
+    await customStatement(
+      'CREATE TRIGGER IF NOT EXISTS notations_ai'
+      ' AFTER INSERT ON notations_table BEGIN'
+      ' INSERT INTO notations_fts(rowid, title, artists, notes)'
+      ' VALUES (new.rowid, new.title, new.artists, new.notes);'
+      ' END',
+    );
+    await customStatement(
+      'CREATE TRIGGER IF NOT EXISTS notations_ad'
+      ' AFTER DELETE ON notations_table BEGIN'
+      ' INSERT INTO notations_fts(notations_fts, rowid, title, artists,'
+      ' notes)'
+      " VALUES ('delete', old.rowid, old.title, old.artists, old.notes);"
+      ' END',
+    );
+    await customStatement(
+      'CREATE TRIGGER IF NOT EXISTS notations_au'
+      ' AFTER UPDATE ON notations_table BEGIN'
+      ' INSERT INTO notations_fts(notations_fts, rowid, title, artists,'
+      ' notes)'
+      " VALUES ('delete', old.rowid, old.title, old.artists, old.notes);"
+      ' INSERT INTO notations_fts(rowid, title, artists, notes)'
+      ' VALUES (new.rowid, new.title, new.artists, new.notes);'
+      ' END',
+    );
+  }
+
+  /// Creates the FTS5 virtual table and the three sync triggers.
+  ///
+  /// The virtual table `notations_fts` indexes the [NotationsTable] columns
+  /// `title`, `artists`, and `notes` using the `unicode61` tokenizer, which
+  /// handles Hindi and Bengali text correctly (data-model.md §2.11).
+  ///
+  /// Three triggers keep the FTS index in sync with the `notations` table:
+  /// - `notations_ai` — AFTER INSERT: adds the new row to FTS.
+  /// - `notations_ad` — AFTER DELETE: removes the deleted row from FTS.
+  /// - `notations_au` — AFTER UPDATE: removes the old row and adds the new
+  ///   one, effectively replacing the FTS entry.
+  ///
+  /// Soft-deleted rows are NOT filtered out here; they remain in the FTS
+  /// index. The `FtsDao.search` query applies `WHERE deleted_at IS NULL`
+  /// via a JOIN to exclude them at query time (data-model.md §2.11).
 
   /// Seeds required initial data after the schema is created for the first
   /// time.

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3779,6 +3779,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       CustomFieldDao(this as AppDatabase);
   late final UserPreferencesDao userPreferencesDao =
       UserPreferencesDao(this as AppDatabase);
+  late final FtsDao ftsDao = FtsDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();

--- a/lib/core/database/daos/fts_dao.dart
+++ b/lib/core/database/daos/fts_dao.dart
@@ -1,0 +1,91 @@
+// FtsDao — Drift DAO for FTS5 full-text search on the notations table.
+//
+// The FTS5 virtual table `notations_fts` is created in AppDatabase.onCreate
+// alongside three SQLite triggers (AFTER INSERT, AFTER UPDATE, AFTER DELETE)
+// that keep the index in sync with the `notations` table.
+//
+// This DAO issues BM25-ranked FTS5 queries with prefix matching and filters
+// out soft-deleted notations via a JOIN on `deleted_at IS NULL`.
+
+import 'dart:developer';
+
+import 'package:drift/drift.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+
+part 'fts_dao.g.dart';
+
+/// Search result row returned by [FtsDao.search].
+///
+/// Contains a subset of [NotationRow] fields needed by the repository layer.
+/// The full [NotationRow] is included so callers can access any column.
+typedef FtsSearchResult = NotationRow;
+
+/// Data-access object for FTS5 full-text search over the notations table.
+///
+/// Queries the `notations_fts` virtual table (created during [AppDatabase]
+/// schema initialisation) and joins back to the `notations` table to filter
+/// soft-deleted rows. Returns BM25-ranked results with prefix matching.
+///
+/// Business logic and domain-model translation belong in the repository layer,
+/// not here.
+@DriftAccessor(tables: [NotationsTable])
+class FtsDao extends DatabaseAccessor<AppDatabase> with _$FtsDaoMixin {
+  /// Creates a [FtsDao] attached to [db].
+  FtsDao(super.db);
+
+  /// Searches notations using an FTS5 BM25-ranked query.
+  ///
+  /// Appends `*` to [query] for prefix matching (e.g. `"Yam"` matches
+  /// `"Yaman"`). Filters out soft-deleted notations (`deleted_at IS NULL`).
+  /// Returns an empty list when [query] is blank or matches nothing.
+  ///
+  /// Results are ordered by BM25 relevance score (best match first).
+  ///
+  /// Parameters:
+  /// - [query]: The user-supplied search string. Prefix matching is applied
+  ///   automatically. Must not contain FTS5 special characters from user input
+  ///   — callers should sanitize before passing here.
+  /// - [limit]: Maximum number of rows to return. Must be > 0.
+  /// - [offset]: Number of leading rows to skip for pagination. Must be >= 0.
+  Future<List<FtsSearchResult>> search(
+    String query, {
+    required int limit,
+    required int offset,
+  }) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return const [];
+    }
+
+    // Parameterised FTS5 query with prefix match and BM25 ranking.
+    // The JOIN to `notations` filters soft-deleted rows without touching
+    // the FTS index directly — soft-deleted rows remain in the FTS table
+    // but are excluded here, as specified in data-model.md §2.11.
+    // Drift generates the SQLite table name as 'notations_table'.
+    final rows = await customSelect(
+      '''
+      SELECT n.*
+      FROM notations_table AS n
+      JOIN notations_fts AS fts ON fts.rowid = n.rowid
+      WHERE notations_fts MATCH ?
+        AND n.deleted_at IS NULL
+      ORDER BY rank
+      LIMIT ? OFFSET ?
+      ''',
+      variables: [
+        Variable.withString('$trimmed*'),
+        Variable.withInt(limit),
+        Variable.withInt(offset),
+      ],
+      readsFrom: {notationsTable},
+    ).get();
+
+    final results = rows.map((row) => notationsTable.map(row.data)).toList();
+    log(
+      'FtsDao: search("$trimmed") returned ${results.length} result(s)',
+      name: 'FtsDao',
+    );
+    return results;
+  }
+}

--- a/lib/core/database/daos/fts_dao.g.dart
+++ b/lib/core/database/daos/fts_dao.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fts_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$FtsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $NotationsTableTable get notationsTable => attachedDatabase.notationsTable;
+  FtsDaoManager get managers => FtsDaoManager(this);
+}
+
+class FtsDaoManager {
+  final _$FtsDaoMixin _db;
+  FtsDaoManager(this._db);
+  $$NotationsTableTableTableManager get notationsTable =>
+      $$NotationsTableTableTableManager(
+          _db.attachedDatabase, _db.notationsTable);
+}

--- a/test/unit/core/database/daos/fts_dao_test.dart
+++ b/test/unit/core/database/daos/fts_dao_test.dart
@@ -1,0 +1,305 @@
+// Unit tests for FtsDao.
+//
+// Covers the FTS5 virtual table, triggers, and the search() method:
+//   - INSERT trigger keeps FTS in sync
+//   - DELETE trigger removes rows from FTS
+//   - UPDATE trigger replaces old FTS entry with new one
+//   - Soft-deleted notations are excluded from search results
+//   - BM25-ranked prefix matching works correctly
+//   - Empty query returns empty list
+//   - Limit and offset are respected
+//
+// Each test group sets up a fresh AppDatabase.forTesting() in setUp and
+// closes it in tearDown, ensuring full isolation between test cases.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/database/daos/fts_dao.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns an ISO 8601 UTC datetime string for test fixtures.
+String _ts(String suffix) => '2024-01-01T${suffix}Z';
+
+/// Inserts a minimal notation row directly into the table and returns its id.
+Future<String> _insertNotation(
+  AppDatabase db, {
+  required String id,
+  String title = 'Yaman Kalyan',
+  String artists = '["Ravi Shankar"]',
+  String notes = '',
+  String? deletedAt,
+}) async {
+  await db.into(db.notationsTable).insert(
+        NotationsTableCompanion.insert(
+          id: id,
+          title: title,
+          artists: Value(artists),
+          notes: Value(notes),
+          createdAt: _ts('10:00:00'),
+          updatedAt: _ts('10:00:00'),
+          deletedAt: Value(deletedAt),
+        ),
+      );
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('FtsDao — INSERT trigger', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      // Force schema creation then set up FTS outside the migration zone.
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('newly inserted notation is findable by title prefix', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav Raag');
+
+      final results = await dao.search('Bhai', limit: 10, offset: 0);
+
+      expect(results, hasLength(1));
+      expect(results.first.id, equals('n1'));
+    });
+
+    test('newly inserted notation is findable by artists prefix', () async {
+      await _insertNotation(
+        db,
+        id: 'n1',
+        title: 'Morning Raga',
+        artists: '["Bismillah Khan"]',
+      );
+
+      final results = await dao.search('Bismil', limit: 10, offset: 0);
+
+      expect(results, hasLength(1));
+      expect(results.first.id, equals('n1'));
+    });
+
+    test('newly inserted notation is findable by notes prefix', () async {
+      await _insertNotation(
+        db,
+        id: 'n1',
+        title: 'Evening Raga',
+        notes: 'Monsoon season composition',
+      );
+
+      final results = await dao.search('Monsoon', limit: 10, offset: 0);
+
+      expect(results, hasLength(1));
+      expect(results.first.id, equals('n1'));
+    });
+  });
+
+  group('FtsDao — DELETE trigger', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('hard-deleted notation is no longer findable via FTS', () async {
+      await _insertNotation(db, id: 'n1', title: 'Darbari Kanada');
+
+      // Verify it was inserted and is findable.
+      final before = await dao.search('Darbari', limit: 10, offset: 0);
+      expect(before, hasLength(1));
+
+      // Hard-delete the notation.
+      await (db.delete(db.notationsTable)..where((t) => t.id.equals('n1')))
+          .go();
+
+      final after = await dao.search('Darbari', limit: 10, offset: 0);
+      expect(after, isEmpty);
+    });
+  });
+
+  group('FtsDao — UPDATE trigger', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('updated title is findable via new title and not old title', () async {
+      await _insertNotation(db, id: 'n1', title: 'Old Title');
+
+      // Update the title.
+      await (db.update(db.notationsTable)..where((t) => t.id.equals('n1')))
+          .write(
+        NotationsTableCompanion(
+          title: const Value('New Title'),
+          updatedAt: Value(_ts('11:00:00')),
+        ),
+      );
+
+      final byNew = await dao.search('New', limit: 10, offset: 0);
+      expect(byNew, hasLength(1));
+      expect(byNew.first.id, equals('n1'));
+
+      final byOld = await dao.search('Old', limit: 10, offset: 0);
+      expect(byOld, isEmpty);
+    });
+  });
+
+  group('FtsDao — soft-delete filtering', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('soft-deleted notation is excluded from search results', () async {
+      await _insertNotation(
+        db,
+        id: 'n1',
+        title: 'Puriya Dhanashri',
+        deletedAt: _ts('11:00:00'),
+      );
+
+      final results = await dao.search('Puriya', limit: 10, offset: 0);
+      expect(results, isEmpty);
+    });
+
+    test(
+        'active notation is returned while soft-deleted one with same '
+        'keyword is excluded', () async {
+      await _insertNotation(db, id: 'n1', title: 'Raag Yaman Active');
+      await _insertNotation(
+        db,
+        id: 'n2',
+        title: 'Raag Yaman Deleted',
+        deletedAt: _ts('11:00:00'),
+      );
+
+      final results = await dao.search('Raag', limit: 10, offset: 0);
+      expect(results, hasLength(1));
+      expect(results.first.id, equals('n1'));
+    });
+  });
+
+  group('FtsDao.search — query semantics', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('returns empty list when query matches no notation', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+
+      final results = await dao.search('Todi', limit: 10, offset: 0);
+      expect(results, isEmpty);
+    });
+
+    test('returns empty list when database has no notations', () async {
+      final results = await dao.search('anything', limit: 10, offset: 0);
+      expect(results, isEmpty);
+    });
+
+    test('prefix matching finds partial word matches', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhimpalasi Raag');
+
+      final results = await dao.search('Bhimpal', limit: 10, offset: 0);
+      expect(results, hasLength(1));
+    });
+
+    test('limit restricts number of returned rows', () async {
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(
+          db,
+          id: 'n$i',
+          title: 'Raag Number $i',
+        );
+      }
+
+      final results = await dao.search('Raag', limit: 3, offset: 0);
+      expect(results, hasLength(3));
+    });
+
+    test('offset skips leading rows', () async {
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(
+          db,
+          id: 'n$i',
+          title: 'Raag Number $i',
+        );
+      }
+
+      final all = await dao.search('Raag', limit: 5, offset: 0);
+      final paged = await dao.search('Raag', limit: 5, offset: 2);
+
+      expect(paged, hasLength(all.length - 2));
+      expect(paged.first.id, equals(all[2].id));
+    });
+
+    test('multiple notations matching same query are all returned', () async {
+      await _insertNotation(db, id: 'n1', title: 'Raag Yaman');
+      await _insertNotation(db, id: 'n2', title: 'Raag Bhairav');
+      await _insertNotation(db, id: 'n3', title: 'Raag Todi');
+
+      final results = await dao.search('Raag', limit: 10, offset: 0);
+      expect(results, hasLength(3));
+    });
+  });
+
+  group('FtsDao.search — empty or trivial query', () {
+    late AppDatabase db;
+    late FtsDao dao;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      dao = FtsDao(db);
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+    });
+    tearDown(() => db.close());
+
+    test('empty string query returns empty list without throwing', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+
+      final results = await dao.search('', limit: 10, offset: 0);
+      expect(results, isEmpty);
+    });
+
+    test('whitespace-only query returns empty list without throwing', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+
+      final results = await dao.search('   ', limit: 10, offset: 0);
+      expect(results, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Closes #67

## Summary

- Creates the `notations_fts` FTS5 virtual table with `unicode61` tokenizer indexing `title`, `artists`, `notes` on `notations_table`
- Creates three SQLite sync triggers (`AFTER INSERT`, `AFTER UPDATE`, `AFTER DELETE` on `notations_table`) to keep the FTS index in sync
- Implements `FtsDao.search(query, limit, offset)` with BM25-ranked prefix matching and `WHERE deleted_at IS NULL` soft-delete filtering
- Exposes `AppDatabase.createFtsSchema()` as an idempotent post-open method; production calls it from `MigrationStrategy.beforeOpen`, tests call it explicitly after opening to work around a Drift `BeforeOpenRunner` zone restriction on `NativeDatabase.memory`

## Type of Change

- `feat` — new database DAO and FTS5 schema

## Commit Convention

`feat(database): implement FTS5 virtual table, triggers, and FtsDao (#67)`

## Test Plan

- `test/unit/core/database/daos/fts_dao_test.dart` — 15 new tests:
  - INSERT trigger: title, artists, notes prefix matching
  - DELETE trigger: hard-deleted rows removed from FTS
  - UPDATE trigger: old entry removed, new entry indexed
  - Soft-delete filtering: `deleted_at IS NULL` join excludes soft-deleted rows
  - Query semantics: no-match returns empty, prefix match, limit, offset, multi-result
  - Edge cases: empty string and whitespace-only query return empty list safely
- All 169 database tests pass (`flutter test test/unit/core/database/`)
- `dart format` and `flutter analyze` pass with zero warnings on touched files

## Checklist

- [x] All tests pass
- [x] `dart format` passes (line length 80)
- [x] `flutter analyze` — zero warnings on new/modified files
- [x] Code review: no CRITICAL or HIGH issues
- [x] PR opened and linked to issue