### PR TITLE
feat(database): add indexes and MigrationStrategy for schema v1 (#68)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -28,7 +28,28 @@ part 'app_database.g.dart';
 
 /// Stores notation metadata. Soft-deleted rows set [deletedAt]; all
 /// repository queries default-filter `WHERE deleted_at IS NULL`.
+///
+/// Three partial indexes optimise the hot read paths described in
+/// data-model.md §4:
+/// - [idx_notations_active_updated]: library list sorted by update time
+/// - [idx_notations_last_played]: recently-played carousel
+/// - [idx_notations_deleted]: trash screen sorted by deletion date
 @DataClassName('NotationRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_notations_active_updated ON notations_table'
+  ' (deleted_at, updated_at DESC)'
+  ' WHERE deleted_at IS NULL',
+)
+@TableIndex.sql(
+  'CREATE INDEX idx_notations_last_played ON notations_table'
+  ' (deleted_at, last_played_at DESC)'
+  ' WHERE deleted_at IS NULL AND last_played_at IS NOT NULL',
+)
+@TableIndex.sql(
+  'CREATE INDEX idx_notations_deleted ON notations_table'
+  ' (deleted_at DESC)'
+  ' WHERE deleted_at IS NOT NULL',
+)
 class NotationsTable extends Table {
   /// UUIDv4 generated at the app layer.
   TextColumn get id => text()();
@@ -77,7 +98,14 @@ class NotationsTable extends Table {
 ///
 /// Each page is ordered within its notation via [pageOrder] (0-indexed).
 /// Pages cascade-delete when their parent notation is hard-deleted.
+///
+/// [idx_pages_notation_order] optimises joins that fetch all pages for a
+/// given notation in display order (data-model.md §4).
 @DataClassName('NotationPageRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_pages_notation_order ON notation_pages_table'
+  ' (notation_id, page_order ASC)',
+)
 class NotationPagesTable extends Table {
   /// UUIDv4 generated at the app layer.
   TextColumn get id => text()();
@@ -135,7 +163,14 @@ class TagsTable extends Table {
 ///
 /// Both sides cascade-delete: removing a notation or a tag silently removes
 /// the corresponding join rows.
+///
+/// [idx_notation_tags_notation] optimises queries that look up all tags for
+/// a given notation (data-model.md §4).
 @DataClassName('NotationTagRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_notation_tags_notation ON notation_tags_table'
+  ' (notation_id)',
+)
 class NotationTagsTable extends Table {
   /// Foreign key to [NotationsTable].
   TextColumn get notationId =>
@@ -176,7 +211,14 @@ class InstrumentClassesTable extends Table {
 /// Soft-deleted (archived) instances retain their rows so existing notation
 /// associations remain visible. Deletion of the parent class is blocked
 /// (RESTRICT) while instances exist.
+///
+/// [idx_instances_class] optimises queries that list instances by class
+/// (e.g. the instrument picker filtered by type) (data-model.md §4).
 @DataClassName('InstrumentInstanceRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_instances_class ON instrument_instances_table'
+  ' (class_id, deleted_at)',
+)
 class InstrumentInstancesTable extends Table {
   /// UUIDv4 generated at the app layer.
   TextColumn get id => text()();
@@ -223,7 +265,14 @@ class InstrumentInstancesTable extends Table {
 ///
 /// Notation side cascades on hard-delete; instrument side restricts (archived
 /// instances are never hard-deleted, so RESTRICT is rarely triggered).
+///
+/// [idx_notation_instruments_notation] optimises joins fetching all
+/// instrument associations for a notation (data-model.md §4).
 @DataClassName('NotationInstrumentRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_notation_instruments_notation'
+  ' ON notation_instruments_table (notation_id)',
+)
 class NotationInstrumentsTable extends Table {
   /// Foreign key to [NotationsTable]. Cascade on notation delete.
   TextColumn get notationId =>
@@ -276,7 +325,14 @@ class CustomFieldDefinitionsTable extends Table {
 /// Sparse column design: only the column matching [fieldType] in the linked
 /// [CustomFieldDefinitionsTable] row is populated; all others are NULL.
 /// Both foreign keys cascade on delete.
+///
+/// [idx_custom_fields_notation] optimises queries that fetch all custom
+/// field values for a given notation (data-model.md §4).
 @DataClassName('NotationCustomFieldRow')
+@TableIndex.sql(
+  'CREATE INDEX idx_custom_fields_notation ON notation_custom_fields_table'
+  ' (notation_id)',
+)
 class NotationCustomFieldsTable extends Table {
   /// Foreign key to [NotationsTable]. Cascade on notation delete.
   TextColumn get notationId =>
@@ -363,10 +419,25 @@ class UserPreferencesTable extends Table {
 
 /// Drift database singleton for Swaralipi.
 ///
-/// Holds all table definitions and exposes a [forTesting] named constructor
-/// for in-memory test instances. Seed data (default tags and user prefs row)
-/// is inserted during [onCreate] in production; tests start with an empty
-/// schema and insert only what each test case requires.
+/// Holds all 10 table definitions, 8 index declarations, and the FTS5 virtual
+/// table + 3 sync triggers created by [createFtsSchema].
+///
+/// ## Schema versioning policy
+///
+/// Every schema change MUST:
+/// 1. Increment [schemaVersion] by 1.
+/// 2. Add a migration function in the [MigrationStrategy.onUpgrade] switch
+///    block that transforms the database from `from` to `to`.
+/// 3. Have a corresponding migration test in
+///    `test/unit/core/database/migration_test.dart` that calls
+///    [validateDatabaseSchema] after running the migration.
+///
+/// No destructive migrations (`DROP TABLE`, `DROP COLUMN`) without a
+/// data-safe alternative. See data-model.md §7 for the full policy.
+///
+/// | schemaVersion | Change |
+/// |---|---|
+/// | 1 | Initial schema: all tables, FTS5, triggers, indexes, seed data |
 @DriftDatabase(
   tables: [
     NotationsTable,
@@ -417,12 +488,31 @@ class AppDatabase extends _$AppDatabase {
           ),
         );
 
+  /// Creates an [AppDatabase] backed by an in-memory SQLite instance with
+  /// seed data inserted on [onCreate].
+  ///
+  /// Used exclusively in migration tests that need to verify the seed data
+  /// produced by [MigrationStrategy.onCreate]. Regular DAO unit tests should
+  /// use [AppDatabase.forTesting] instead, which starts with an empty schema.
+  ///
+  /// After constructing, callers that require FTS5 search must call
+  /// [createFtsSchema] once after the first query.
+  AppDatabase.forTestingWithSeed()
+      : _seedOnCreate = true,
+        super(
+          NativeDatabase.memory(
+            setup: (db) => db.execute('PRAGMA foreign_keys = ON;'),
+          ),
+        );
+
   @override
   int get schemaVersion => 1;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (m) async {
+          // Creates all tables and indexes declared in the @DriftDatabase
+          // annotation.  For schema v1 this is the only migration path.
           await m.createAll();
           if (_seedOnCreate) {
             await _seedInitialData();

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3768,6 +3768,24 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $NotationCustomFieldsTableTable(this);
   late final $UserPreferencesTableTable userPreferencesTable =
       $UserPreferencesTableTable(this);
+  late final Index idxNotationsActiveUpdated = Index(
+      'idx_notations_active_updated',
+      'CREATE INDEX idx_notations_active_updated ON notations_table (deleted_at, updated_at DESC) WHERE deleted_at IS NULL');
+  late final Index idxNotationsLastPlayed = Index('idx_notations_last_played',
+      'CREATE INDEX idx_notations_last_played ON notations_table (deleted_at, last_played_at DESC) WHERE deleted_at IS NULL AND last_played_at IS NOT NULL');
+  late final Index idxNotationsDeleted = Index('idx_notations_deleted',
+      'CREATE INDEX idx_notations_deleted ON notations_table (deleted_at DESC) WHERE deleted_at IS NOT NULL');
+  late final Index idxPagesNotationOrder = Index('idx_pages_notation_order',
+      'CREATE INDEX idx_pages_notation_order ON notation_pages_table (notation_id, page_order ASC)');
+  late final Index idxNotationTagsNotation = Index('idx_notation_tags_notation',
+      'CREATE INDEX idx_notation_tags_notation ON notation_tags_table (notation_id)');
+  late final Index idxInstancesClass = Index('idx_instances_class',
+      'CREATE INDEX idx_instances_class ON instrument_instances_table (class_id, deleted_at)');
+  late final Index idxNotationInstrumentsNotation = Index(
+      'idx_notation_instruments_notation',
+      'CREATE INDEX idx_notation_instruments_notation ON notation_instruments_table (notation_id)');
+  late final Index idxCustomFieldsNotation = Index('idx_custom_fields_notation',
+      'CREATE INDEX idx_custom_fields_notation ON notation_custom_fields_table (notation_id)');
   late final NotationDao notationDao = NotationDao(this as AppDatabase);
   late final NotationPageDao notationPageDao =
       NotationPageDao(this as AppDatabase);
@@ -3794,7 +3812,15 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         notationInstrumentsTable,
         customFieldDefinitionsTable,
         notationCustomFieldsTable,
-        userPreferencesTable
+        userPreferencesTable,
+        idxNotationsActiveUpdated,
+        idxNotationsLastPlayed,
+        idxNotationsDeleted,
+        idxPagesNotationOrder,
+        idxNotationTagsNotation,
+        idxInstancesClass,
+        idxNotationInstrumentsNotation,
+        idxCustomFieldsNotation
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(

--- a/test/unit/core/database/daos/notation_page_dao_test.dart
+++ b/test/unit/core/database/daos/notation_page_dao_test.dart
@@ -161,9 +161,9 @@ void main() {
     tearDown(() => db.close());
 
     test('updates imagePath of an existing page', () async {
-      final companion = NotationPagesTableCompanion(
-        id: const Value('p1'),
-        imagePath: const Value('notations/n1/page_p1_edited.jpg'),
+      const companion = NotationPagesTableCompanion(
+        id: Value('p1'),
+        imagePath: Value('notations/n1/page_p1_edited.jpg'),
       );
 
       await dao.updatePage(companion);
@@ -175,9 +175,9 @@ void main() {
     });
 
     test('returns false for a non-existent id', () async {
-      final companion = NotationPagesTableCompanion(
-        id: const Value('ghost'),
-        imagePath: const Value('any/path'),
+      const companion = NotationPagesTableCompanion(
+        id: Value('ghost'),
+        imagePath: Value('any/path'),
       );
 
       final updated = await dao.updatePage(companion);

--- a/test/unit/core/database/migration_test.dart
+++ b/test/unit/core/database/migration_test.dart
@@ -1,0 +1,277 @@
+// Migration tests for AppDatabase — schema v1.
+//
+// Verifies that [MigrationStrategy.onCreate] produces the exact schema
+// described in docs/02-technical/data-model.md, including:
+//   - All 10 tables
+//   - All 9 indexes (partial and non-partial)
+//   - The FTS5 virtual table (notations_fts) and its 3 sync triggers
+//   - Seed data: 5 default tags and the singleton user_preferences row
+//   - schemaVersion == 1
+//
+// [validateDatabaseSchema] (from drift_dev/api/migrations_native.dart) is
+// used to compare the live schema against Drift's reference schema, giving
+// a single authoritative assertion that no table, column or constraint
+// differs from the Drift-generated expectation.
+//
+// Direct sqlite_master queries verify FTS5 and trigger presence, which are
+// outside Drift's regular table registry and therefore not covered by
+// [validateDatabaseSchema] alone.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift_dev/api/migrations_native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Drift-generated table entity names for all 10 tables in schema v1.
+const _expectedTables = {
+  'notations_table',
+  'notation_pages_table',
+  'tags_table',
+  'notation_tags_table',
+  'instrument_classes_table',
+  'instrument_instances_table',
+  'notation_instruments_table',
+  'custom_field_definitions_table',
+  'notation_custom_fields_table',
+  'user_preferences_table',
+};
+
+/// Index names as defined in data-model.md §4.
+const _expectedIndexes = {
+  'idx_notations_active_updated',
+  'idx_notations_last_played',
+  'idx_notations_deleted',
+  'idx_pages_notation_order',
+  'idx_notation_tags_notation',
+  'idx_notation_instruments_notation',
+  'idx_instances_class',
+  'idx_custom_fields_notation',
+};
+
+/// FTS5 virtual table name.
+const _ftsTableName = 'notations_fts';
+
+/// FTS5 sync trigger names.
+const _expectedTriggers = {'notations_ai', 'notations_ad', 'notations_au'};
+
+/// Default tag names seeded during onCreate.
+const _expectedTagNames = {'Raag', 'Bhajan', 'Classical', 'Folk', 'Devotional'};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Queries [sqlite_master] and returns entity names matching [type].
+///
+/// Parameters:
+/// - [db]: The open [AppDatabase] to query.
+/// - [type]: One of `'table'`, `'index'`, or `'trigger'`.
+Future<Set<String>> _schemaNames(AppDatabase db, String type) async {
+  final rows = await db.customSelect(
+    'SELECT name FROM sqlite_master WHERE type = ?',
+    variables: [Variable.withString(type)],
+  ).get();
+  return rows.map((r) => r.read<String>('name')).toSet();
+}
+
+/// Opens a seeded in-memory [AppDatabase] for migration tests.
+///
+/// Seed data is inserted (mirrors production behaviour). FTS schema is
+/// created explicitly because Drift's [MigrationStrategy.beforeOpen] zone
+/// prevents virtual-table DDL on in-memory connections.
+Future<AppDatabase> _openSeeded() async {
+  final db = AppDatabase.forTestingWithSeed();
+  // First query triggers onCreate via Drift's lazy-open mechanism.
+  await db.select(db.notationsTable).get();
+  // FTS must be created after the first query (see AppDatabase docs).
+  await db.createFtsSchema();
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // Suppress drift's "multiple database" warning in tests.
+  setUpAll(() => driftRuntimeOptions.dontWarnAboutMultipleDatabases = true);
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — schema version', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test('schemaVersion is 1', () {
+      expect(db.schemaVersion, 1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — Drift schema validation', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test(
+        'validateDatabaseSchema passes — all tables, columns and '
+        'constraints match the Drift definition', () async {
+      // Compares the live database schema against the reference schema that
+      // Drift builds from scratch using createAll().  A SchemaMismatch
+      // exception indicates the migration produced an incorrect schema.
+      //
+      // validateDropped is false (the default) because the FTS5 virtual
+      // table and its shadow tables (notations_fts_*) are created via
+      // customStatement and are not registered in Drift's table registry.
+      // Presence of the FTS5 objects is asserted separately in the
+      // "FTS5 virtual table and triggers" group.
+      await expectLater(
+        db.validateDatabaseSchema(),
+        completes,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — table presence', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test('all 10 tables are present', () async {
+      final tables = await _schemaNames(db, 'table');
+      for (final expected in _expectedTables) {
+        expect(tables, contains(expected), reason: 'missing table: $expected');
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — index presence', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test('all 9 indexes defined in data-model.md §4 are present', () async {
+      final indexes = await _schemaNames(db, 'index');
+      for (final expected in _expectedIndexes) {
+        expect(indexes, contains(expected), reason: 'missing index: $expected');
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — FTS5 virtual table and triggers', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test('notations_fts virtual table exists', () async {
+      final tables = await _schemaNames(db, 'table');
+      expect(tables, contains(_ftsTableName));
+    });
+
+    test('all 3 FTS5 sync triggers are present', () async {
+      final triggers = await _schemaNames(db, 'trigger');
+      for (final expected in _expectedTriggers) {
+        expect(
+          triggers,
+          contains(expected),
+          reason: 'missing trigger: $expected',
+        );
+      }
+    });
+
+    test('FTS index is searchable after notation insert', () async {
+      await db.into(db.notationsTable).insert(
+            NotationsTableCompanion.insert(
+              id: 'n-fts-1',
+              title: 'Bhairav Kalyan',
+              createdAt: '2024-01-01T10:00:00Z',
+              updatedAt: '2024-01-01T10:00:00Z',
+            ),
+          );
+
+      // FTS match returns the matching row.
+      final results = await db
+          .customSelect(
+            'SELECT notations_table.id FROM notations_table '
+            'JOIN notations_fts ON notations_table.rowid = notations_fts.rowid '
+            "WHERE notations_fts MATCH 'Bhairav'",
+          )
+          .get();
+      expect(results, hasLength(1));
+      expect(results.first.read<String>('id'), 'n-fts-1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — seed data', () {
+    late AppDatabase db;
+    setUp(() async => db = await _openSeeded());
+    tearDown(() => db.close());
+
+    test('exactly 5 default tags are seeded', () async {
+      final tags = await db.select(db.tagsTable).get();
+      expect(tags, hasLength(5));
+    });
+
+    test('seeded tag names match the spec', () async {
+      final tags = await db.select(db.tagsTable).get();
+      final names = tags.map((t) => t.name).toSet();
+      expect(names, equals(_expectedTagNames));
+    });
+
+    test('each default tag has a valid Catppuccin hex color', () async {
+      final tags = await db.select(db.tagsTable).get();
+      for (final tag in tags) {
+        expect(
+          tag.colorHex,
+          matches(RegExp(r'^#[0-9a-f]{6}$')),
+          reason: 'invalid color for tag ${tag.name}: ${tag.colorHex}',
+        );
+      }
+    });
+
+    test('singleton user_preferences row exists with id = 1', () async {
+      final rows = await db.select(db.userPreferencesTable).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.id, 1);
+    });
+
+    test('user_preferences row has correct default values', () async {
+      final prefs = await db.select(db.userPreferencesTable).getSingle();
+      expect(prefs.themeMode, 'system');
+      expect(prefs.colorSchemeMode, 'catppuccin');
+      expect(prefs.defaultSort, 'created_at_desc');
+      expect(prefs.defaultView, 'list');
+      expect(prefs.userName, 'Musician');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v1 — forTesting mode has no seed data', () {
+    late AppDatabase db;
+    setUp(() {
+      db = AppDatabase.forTesting();
+    });
+    tearDown(() => db.close());
+
+    test('no tags are seeded in forTesting mode', () async {
+      await db.select(db.notationsTable).get();
+      final tags = await db.select(db.tagsTable).get();
+      expect(tags, isEmpty);
+    });
+
+    test('no user_preferences row in forTesting mode', () async {
+      await db.select(db.notationsTable).get();
+      final prefs = await db.select(db.userPreferencesTable).get();
+      expect(prefs, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Closes #68

## Summary

- Added 8 \`@TableIndex.sql(...)\` annotations (3 partial, 5 regular) to \`AppDatabase\` table classes so Drift's \`createAll()\` executes all indexes from data-model.md §4 during schema v1 \`onCreate\`
- Added \`AppDatabase.forTestingWithSeed()\` named constructor for migration tests that verify seed data without touching disk
- Documented the schema versioning policy (schemaVersion increment + migration function + migration test) in the \`AppDatabase\` class comment
- Added 14 migration tests covering schema structure, Drift schema validation, indexes, FTS5, triggers, seed data, and test isolation

## Type of Change

- [x] feat — new capability
- [x] test — tests only

## Commit Convention

\`feat(database): add indexes and forTestingWithSeed constructor to AppDatabase (#68)\`

## Test Plan

- \`test/unit/core/database/migration_test.dart\` — 14 new tests (all pass)
  - Migration v1 — schema version (1 test)
  - Migration v1 — Drift schema validation via \`validateDatabaseSchema\` (1 test)
  - Migration v1 — table presence: all 10 tables (1 test)
  - Migration v1 — index presence: all 8 indexes from data-model.md §4 (1 test)
  - Migration v1 — FTS5 virtual table, 3 sync triggers, FTS searchability (3 tests)
  - Migration v1 — seed data: tag count, names, colors, user_preferences (5 tests)
  - Migration v1 — forTesting isolation: no seed data in test mode (2 tests)
- Full database test suite: 182 tests passed, 0 failed
- \`flutter analyze\`: 0 warnings in touched files
- \`dart format\`: applied

## Checklist

- [x] No \`print\` statements (use \`dart:developer\` \`log\`)
- [x] No relative imports
- [x] No \`late\` without guaranteed init
- [x] No bare \`catch (e)\`
- [x] Generated files committed (\`.g.dart\`)
- [x] No hardcoded secrets