### PR TITLE
feat(storage): implement FileStorageService (#69)

### DIFF
--- a/lib/core/storage/file_storage_service.dart
+++ b/lib/core/storage/file_storage_service.dart
@@ -1,0 +1,182 @@
+// FileStorageService — manages JPEG image files for notation pages.
+//
+// Writes original images under <appDocDir>/notations/<notationId>/ and
+// exposes helpers to resolve, delete, and clean up those files. Only relative
+// paths are stored in the database; all resolution to absolute paths happens
+// at runtime via [getAbsolutePath].
+//
+// The [dirProvider] constructor parameter defaults to
+// [getApplicationDocumentsDirectory] from `path_provider` and can be
+// overridden in unit tests to inject a temporary directory without touching
+// the real file system.
+
+import 'dart:developer';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// The sub-directory under `appDocDir` where notation images are stored.
+const String _kNotationsDir = 'notations';
+
+/// Suffix appended to every original page file name.
+const String _kOriginalSuffix = '_original.jpg';
+
+/// Manages JPEG image files for notation pages under `appDocDir`.
+///
+/// All public methods operate on relative paths (e.g.
+/// `notations/<notationId>/page_0_original.jpg`) that are safe to persist in
+/// the database. Absolute path resolution always happens at call-time so that
+/// paths remain valid if the device's `appDocDir` changes between app
+/// versions.
+///
+/// Inject [dirProvider] in tests to replace the real [getApplicationDocumentsDirectory]
+/// with a temporary directory.
+class FileStorageService {
+  /// Creates a [FileStorageService].
+  ///
+  /// Parameters:
+  /// - [dirProvider]: Async factory that returns the root application
+  ///   documents directory. Defaults to [getApplicationDocumentsDirectory].
+  ///   Override in unit tests to provide a temporary directory.
+  FileStorageService({
+    Future<Directory> Function()? dirProvider,
+  }) : _dirProvider = dirProvider ?? getApplicationDocumentsDirectory;
+
+  final Future<Directory> Function() _dirProvider;
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /// Writes [bytes] as a JPEG file for [notationId] at [pageIndex].
+  ///
+  /// The file is placed at
+  /// `<appDocDir>/notations/<notationId>/page_<pageIndex>_original.jpg`.
+  /// Parent directories are created automatically. If a file already exists
+  /// at that path it is overwritten.
+  ///
+  /// Returns the relative path from `appDocDir` to the written file
+  /// (e.g. `notations/abc-123/page_0_original.jpg`). Store this value in the
+  /// database and resolve it later with [getAbsolutePath].
+  ///
+  /// Parameters:
+  /// - [bytes]: The raw JPEG bytes to persist.
+  /// - [notationId]: The UUIDv4 identifier of the owning notation.
+  /// - [pageIndex]: The zero-based page index used to build the file name.
+  Future<String> saveImage(
+    Uint8List bytes,
+    String notationId,
+    int pageIndex,
+  ) async {
+    final relativePath = _buildRelativePath(notationId, pageIndex);
+    final absPath = await _resolveAbsolute(relativePath);
+    final file = File(absPath);
+
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes, flush: true);
+
+    log(
+      'FileStorageService: saved ${bytes.length} bytes → $relativePath',
+      name: 'FileStorageService',
+    );
+
+    return relativePath;
+  }
+
+  /// Resolves [relativePath] to the absolute path under the current
+  /// `appDocDir`.
+  ///
+  /// Re-root is performed at call-time so the result is always valid even
+  /// after app updates that may change `appDocDir` on some platforms.
+  ///
+  /// Parameters:
+  /// - [relativePath]: A path relative to `appDocDir` as returned by
+  ///   [saveImage].
+  Future<String> getAbsolutePath(String relativePath) {
+    return _resolveAbsolute(relativePath);
+  }
+
+  /// Deletes the file at [relativePath].
+  ///
+  /// If the file does not exist the call is a no-op (idempotent). Other
+  /// [FileSystemException] variants are re-thrown so callers can handle
+  /// unexpected errors.
+  ///
+  /// Parameters:
+  /// - [relativePath]: A path relative to `appDocDir` as returned by
+  ///   [saveImage].
+  Future<void> deletePageFile(String relativePath) async {
+    final absPath = await _resolveAbsolute(relativePath);
+    final file = File(absPath);
+
+    if (!file.existsSync()) {
+      log(
+        'FileStorageService: deletePageFile — file not found, skipping: '
+        '$relativePath',
+        name: 'FileStorageService',
+      );
+      return;
+    }
+
+    await file.delete();
+    log(
+      'FileStorageService: deleted page file $relativePath',
+      name: 'FileStorageService',
+    );
+  }
+
+  /// Deletes the entire `notations/<notationId>/` directory and all its
+  /// contents.
+  ///
+  /// If the directory does not exist the call is a no-op (idempotent). Other
+  /// [FileSystemException] variants are re-thrown.
+  ///
+  /// Parameters:
+  /// - [notationId]: The UUIDv4 identifier of the notation whose directory
+  ///   should be removed.
+  Future<void> deleteNotationDirectory(String notationId) async {
+    final appDocDir = await _dirProvider();
+    final dirPath = p.join(appDocDir.path, _kNotationsDir, notationId);
+    final dir = Directory(dirPath);
+
+    if (!dir.existsSync()) {
+      log(
+        'FileStorageService: deleteNotationDirectory — directory not found, '
+        'skipping: $notationId',
+        name: 'FileStorageService',
+      );
+      return;
+    }
+
+    await dir.delete(recursive: true);
+    log(
+      'FileStorageService: deleted notation directory for $notationId',
+      name: 'FileStorageService',
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /// Builds the relative path for a page image.
+  ///
+  /// Returns [relativePath]:
+  ///   `notations/<notationId>/page_<pageIndex>_original.jpg`
+  String _buildRelativePath(String notationId, int pageIndex) {
+    return p.join(
+      _kNotationsDir,
+      notationId,
+      'page_$pageIndex$_kOriginalSuffix',
+    );
+  }
+
+  /// Joins [relativePath] with the current `appDocDir` to produce an absolute
+  /// path.
+  Future<String> _resolveAbsolute(String relativePath) async {
+    final appDocDir = await _dirProvider();
+    return p.join(appDocDir.path, relativePath);
+  }
+}

--- a/test/unit/core/storage/file_storage_service_test.dart
+++ b/test/unit/core/storage/file_storage_service_test.dart
@@ -1,0 +1,211 @@
+// Unit tests for FileStorageService.
+//
+// Covers all four public methods:
+//   saveImage, getAbsolutePath, deletePageFile, deleteNotationDirectory.
+//
+// Uses a real temporary directory (via [Directory.systemTemp]) so that actual
+// file-system semantics are exercised without relying on a real Android
+// appDocDir. The [FileStorageService] accepts a [dirProvider] callback that is
+// overridden to return the temp directory in every test group.
+//
+// Each test group creates a fresh temp dir in setUp and deletes it in tearDown
+// to guarantee full isolation.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a temp directory and returns a [FileStorageService] that uses it.
+FileStorageService _makeService(Directory tempDir) {
+  return FileStorageService(dirProvider: () async => tempDir);
+}
+
+/// Minimal valid JPEG header (two bytes) — enough to round-trip the test.
+final Uint8List _minimalJpeg = Uint8List.fromList([0xFF, 0xD8]);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('FileStorageService.saveImage', () {
+    late Directory tempDir;
+    late FileStorageService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fss_test_save_');
+      service = _makeService(tempDir);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('writes bytes to expected absolute path', () async {
+      final relativePath = await service.saveImage(_minimalJpeg, 'n1', 0);
+
+      final absPath = await service.getAbsolutePath(relativePath);
+      final file = File(absPath);
+
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsBytesSync(), equals(_minimalJpeg));
+    });
+
+    test('returns path matching notations/<notationId>/page_<idx>_original.jpg',
+        () async {
+      final relativePath = await service.saveImage(_minimalJpeg, 'abc-123', 2);
+
+      expect(
+        relativePath,
+        equals(p.join('notations', 'abc-123', 'page_2_original.jpg')),
+      );
+    });
+
+    test('creates parent directories when they do not exist', () async {
+      final relativePath =
+          await service.saveImage(_minimalJpeg, 'new-notation', 0);
+
+      final absPath = await service.getAbsolutePath(relativePath);
+      expect(File(absPath).existsSync(), isTrue);
+    });
+
+    test('overwrites an existing file with new bytes', () async {
+      final original = Uint8List.fromList([0xFF, 0xD8, 0x01]);
+      final replacement = Uint8List.fromList([0xFF, 0xD8, 0x02]);
+
+      await service.saveImage(original, 'n1', 0);
+      await service.saveImage(replacement, 'n1', 0);
+
+      final absPath =
+          await service.getAbsolutePath('notations/n1/page_0_original.jpg');
+      expect(File(absPath).readAsBytesSync(), equals(replacement));
+    });
+
+    test('different page indices produce distinct paths', () async {
+      final path0 = await service.saveImage(_minimalJpeg, 'n1', 0);
+      final path1 = await service.saveImage(_minimalJpeg, 'n1', 1);
+
+      expect(path0, isNot(equals(path1)));
+    });
+  });
+
+  group('FileStorageService.getAbsolutePath', () {
+    late Directory tempDir;
+    late FileStorageService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fss_test_path_');
+      service = _makeService(tempDir);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('re-roots relative path under the provided appDocDir', () async {
+      const relative = 'notations/n1/page_0_original.jpg';
+      final abs = await service.getAbsolutePath(relative);
+
+      expect(abs, equals(p.join(tempDir.path, relative)));
+    });
+
+    test('is stable across multiple calls with the same relative path',
+        () async {
+      const relative = 'notations/n2/page_1_original.jpg';
+      final abs1 = await service.getAbsolutePath(relative);
+      final abs2 = await service.getAbsolutePath(relative);
+
+      expect(abs1, equals(abs2));
+    });
+  });
+
+  group('FileStorageService.deletePageFile', () {
+    late Directory tempDir;
+    late FileStorageService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fss_test_del_page_');
+      service = _makeService(tempDir);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('removes a file that exists', () async {
+      final relativePath = await service.saveImage(_minimalJpeg, 'n1', 0);
+      final absPath = await service.getAbsolutePath(relativePath);
+
+      expect(File(absPath).existsSync(), isTrue);
+
+      await service.deletePageFile(relativePath);
+
+      expect(File(absPath).existsSync(), isFalse);
+    });
+
+    test('is idempotent when file does not exist', () async {
+      // Must not throw.
+      await service.deletePageFile('notations/ghost/page_0_original.jpg');
+    });
+
+    test('does not remove sibling files in the same directory', () async {
+      await service.saveImage(_minimalJpeg, 'n1', 0);
+      await service.saveImage(_minimalJpeg, 'n1', 1);
+
+      await service.deletePageFile('notations/n1/page_0_original.jpg');
+
+      final absPath1 =
+          await service.getAbsolutePath('notations/n1/page_1_original.jpg');
+      expect(File(absPath1).existsSync(), isTrue);
+    });
+  });
+
+  group('FileStorageService.deleteNotationDirectory', () {
+    late Directory tempDir;
+    late FileStorageService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fss_test_del_dir_');
+      service = _makeService(tempDir);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('removes the entire notation directory including all pages', () async {
+      await service.saveImage(_minimalJpeg, 'n1', 0);
+      await service.saveImage(_minimalJpeg, 'n1', 1);
+
+      final dirPath = p.join(tempDir.path, 'notations', 'n1');
+      expect(Directory(dirPath).existsSync(), isTrue);
+
+      await service.deleteNotationDirectory('n1');
+
+      expect(Directory(dirPath).existsSync(), isFalse);
+    });
+
+    test('is idempotent when directory does not exist', () async {
+      // Must not throw.
+      await service.deleteNotationDirectory('no-such-notation');
+    });
+
+    test('does not affect directories for other notations', () async {
+      await service.saveImage(_minimalJpeg, 'n1', 0);
+      await service.saveImage(_minimalJpeg, 'n2', 0);
+
+      await service.deleteNotationDirectory('n1');
+
+      final n2DirPath = p.join(tempDir.path, 'notations', 'n2');
+      expect(Directory(n2DirPath).existsSync(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Closes #69

## Summary
- Adds `FileStorageService` at `lib/core/storage/file_storage_service.dart`
- Implements `saveImage`, `getAbsolutePath`, `deletePageFile`, and `deleteNotationDirectory` per SDS §6.2
- Uses injectable `dirProvider` callback so unit tests bypass `path_provider` entirely without any mocking framework
- Stores only relative paths; absolute resolution always happens at call-time

## Type of Change
- [x] feat — new capability
- [x] test — tests only

## Commit Convention
`feat(storage): implement FileStorageService (#69)`

## Test Plan
- [x] Unit tests written — 13 tests covering all four public methods
- [x] `flutter test` passes locally — 13/13 pass
- [x] Coverage: 4 methods × multiple branches each, all exercised
- [x] `flutter analyze --fatal-infos --fatal-warnings` clean — 0 issues
- [x] `dart format` applied — 0 changes

## Screenshots / Recordings
N/A — no UI change

## Checklist
- [x] No `print` statements (uses `dart:developer` `log`)
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] Generated files committed (`.g.dart`) — N/A (no code gen)
- [x] No hardcoded secrets