### PR TITLE
feat(search): implement SearchService with FTS5 BM25 query (#74)

### DIFF
--- a/lib/core/search/search_service.dart
+++ b/lib/core/search/search_service.dart
@@ -1,0 +1,171 @@
+// SearchService — FTS5 BM25 full-text search over the notations table.
+//
+// Implements two-phase search as specified in sds.md §6.4:
+//   1. FTS phase  — SQLite FTS5 query via FtsDao (BM25 ranked, prefix-matched).
+//   2. Empty path — direct SQL query ordered by updated_at DESC when the
+//                   caller supplies a blank query.
+//
+// Returns only notation IDs (List<String>). Callers are responsible for
+// hydrating full notation objects from NotationRepository.
+//
+// Performance target: < 200 ms on 1 000 notations (sds.md §9.1).
+
+import 'dart:developer';
+
+import 'package:drift/drift.dart';
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/database/daos/fts_dao.dart';
+
+/// Default maximum results returned per page.
+const int _kDefaultLimit = 20;
+
+/// Default number of leading results to skip.
+const int _kDefaultOffset = 0;
+
+/// Service that runs FTS5 BM25 ranked queries and returns notation IDs.
+///
+/// For non-empty queries the service delegates to [FtsDao], which issues a
+/// parameterised FTS5 `MATCH '<query>*'` query with prefix matching and
+/// excludes soft-deleted notations via a JOIN.
+///
+/// For empty / whitespace-only queries the service falls back to a direct
+/// table scan that returns all active notation IDs ordered by `updated_at`
+/// descending — matching the default library sort (data-model.md §8.1).
+///
+/// Inject [AppDatabase] and [FtsDao] via the constructor; this keeps the
+/// service testable with [AppDatabase.forTesting] without any additional
+/// mocking infrastructure.
+class SearchService {
+  /// Creates a [SearchService].
+  ///
+  /// Parameters:
+  /// - [db]: The application database instance. Used for the empty-query
+  ///   fallback and for [reindexAll].
+  /// - [ftsDao]: The FTS5 DAO used for ranked full-text queries.
+  const SearchService({
+    required AppDatabase db,
+    required FtsDao ftsDao,
+  })  : _db = db,
+        _ftsDao = ftsDao;
+
+  final AppDatabase _db;
+  final FtsDao _ftsDao;
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /// Searches notations by full-text query and returns a list of notation IDs.
+  ///
+  /// When [query] is empty or contains only whitespace, returns all active
+  /// notation IDs ordered by `updated_at` descending (most-recently updated
+  /// first). When [query] is non-empty, delegates to [FtsDao] for a BM25-
+  /// ranked FTS5 query with prefix matching (e.g. `"Bhai"` matches
+  /// `"Bhairavi"`).
+  ///
+  /// Soft-deleted notations are always excluded.
+  ///
+  /// Returns a [List<String>] of notation UUIDs. The list is empty when no
+  /// notations match.
+  ///
+  /// Parameters:
+  /// - [query]: The user-supplied search string. Prefix matching is applied
+  ///   automatically for non-empty values. Whitespace-only strings are treated
+  ///   as empty.
+  /// - [limit]: Maximum number of IDs to return. Must be > 0.
+  ///   Defaults to [_kDefaultLimit] (20).
+  /// - [offset]: Number of leading results to skip for pagination.
+  ///   Must be >= 0. Defaults to 0.
+  Future<List<String>> search(
+    String query, {
+    int limit = _kDefaultLimit,
+    int offset = _kDefaultOffset,
+  }) async {
+    final trimmed = query.trim();
+
+    if (trimmed.isEmpty) {
+      return _allActiveIds(limit: limit, offset: offset);
+    }
+
+    return _ftsSearch(trimmed, limit: limit, offset: offset);
+  }
+
+  /// Rebuilds the FTS5 index from scratch.
+  ///
+  /// Drops the existing `notations_fts` virtual table and its sync triggers,
+  /// then recreates them via [AppDatabase.createFtsSchema]. Existing rows in
+  /// `notations_table` are re-indexed automatically by the `content=` option
+  /// on the FTS5 table.
+  ///
+  /// Call this on startup if the FTS index may be out of sync (e.g. after a
+  /// crash during a write). The operation is safe to call at any time — the
+  /// IF NOT EXISTS / DROP approach ensures no duplicate objects are created.
+  Future<void> reindexAll() async {
+    log('SearchService: reindexAll — dropping FTS schema',
+        name: 'SearchService');
+
+    await _db.customStatement('DROP TABLE IF EXISTS notations_fts');
+    await _db.customStatement('DROP TRIGGER IF EXISTS notations_ai');
+    await _db.customStatement('DROP TRIGGER IF EXISTS notations_ad');
+    await _db.customStatement('DROP TRIGGER IF EXISTS notations_au');
+
+    await _db.createFtsSchema();
+
+    // Repopulate the FTS index from the content table. When the virtual table
+    // uses `content='notations_table'`, SQLite stores no row data inside the
+    // FTS index itself — only the BM25 ranking structures. After a fresh
+    // CREATE VIRTUAL TABLE the index is empty; issuing the special 'rebuild'
+    // command scans the content table and rebuilds the full FTS index.
+    await _db.customStatement(
+      "INSERT INTO notations_fts(notations_fts) VALUES('rebuild')",
+    );
+
+    log('SearchService: reindexAll — FTS schema rebuilt',
+        name: 'SearchService');
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /// Returns all active notation IDs ordered by [updatedAt] descending.
+  ///
+  /// Used as the fallback path when [search] is called with an empty query.
+  Future<List<String>> _allActiveIds({
+    required int limit,
+    required int offset,
+  }) async {
+    final rows = await (_db.select(_db.notationsTable)
+          ..where((t) => t.deletedAt.isNull())
+          ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)])
+          ..limit(limit, offset: offset))
+        .get();
+
+    log(
+      'SearchService: empty query returned ${rows.length} ID(s)',
+      name: 'SearchService',
+    );
+
+    return List.unmodifiable(rows.map((r) => r.id));
+  }
+
+  /// Delegates to [FtsDao] and extracts notation IDs from the result rows.
+  Future<List<String>> _ftsSearch(
+    String trimmedQuery, {
+    required int limit,
+    required int offset,
+  }) async {
+    final rows = await _ftsDao.search(
+      trimmedQuery,
+      limit: limit,
+      offset: offset,
+    );
+
+    log(
+      'SearchService: FTS query "$trimmedQuery" returned ${rows.length} ID(s)',
+      name: 'SearchService',
+    );
+
+    return List.unmodifiable(rows.map((r) => r.id));
+  }
+}

--- a/test/unit/core/search/search_service_test.dart
+++ b/test/unit/core/search/search_service_test.dart
@@ -1,0 +1,313 @@
+// Unit tests for SearchService.
+//
+// Covers all branches of search() and reindexAll():
+//   - Empty / whitespace-only query returns all active notation IDs ordered
+//     by updated_at DESC
+//   - Non-empty query delegates to FtsDao and returns notation IDs
+//   - Prefix matching is forwarded correctly to FtsDao
+//   - Pagination (limit / offset) is respected
+//   - Consistent pages with no duplicates across page boundaries
+//   - reindexAll() rebuilds the FTS index via AppDatabase.createFtsSchema
+//
+// FtsDao is tested end-to-end via AppDatabase.forTesting(), meaning these
+// tests exercise the real SQLite FTS5 engine, matching the approach used in
+// fts_dao_test.dart.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/database/daos/fts_dao.dart';
+import 'package:swaralipi/core/search/search_service.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns an ISO 8601 UTC datetime string for test fixtures.
+String _ts(String suffix) => '2024-01-01T${suffix}Z';
+
+/// Inserts a minimal notation row and returns its id.
+Future<String> _insertNotation(
+  AppDatabase db, {
+  required String id,
+  String title = 'Yaman Kalyan',
+  String artists = '["Ravi Shankar"]',
+  String notes = '',
+  String updatedAt = '10:00:00',
+  String? deletedAt,
+}) async {
+  await db.into(db.notationsTable).insert(
+        NotationsTableCompanion.insert(
+          id: id,
+          title: title,
+          artists: Value(artists),
+          notes: Value(notes),
+          createdAt: _ts('09:00:00'),
+          updatedAt: _ts(updatedAt),
+          deletedAt: Value(deletedAt),
+        ),
+      );
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('SearchService.search — empty query', () {
+    late AppDatabase db;
+    late SearchService service;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+      service = SearchService(db: db, ftsDao: FtsDao(db));
+    });
+    tearDown(() => db.close());
+
+    test('returns empty list when database has no notations', () async {
+      final ids = await service.search('');
+      expect(ids, isEmpty);
+    });
+
+    test('returns all active notation IDs for empty query', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+      await _insertNotation(db, id: 'n2', title: 'Yaman');
+
+      final ids = await service.search('');
+      expect(ids, containsAll(['n1', 'n2']));
+      expect(ids, hasLength(2));
+    });
+
+    test('whitespace-only query is treated as empty and returns all active',
+        () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+
+      final ids = await service.search('   ');
+      expect(ids, equals(['n1']));
+    });
+
+    test('empty query excludes soft-deleted notations', () async {
+      await _insertNotation(db, id: 'n1', title: 'Active Raag');
+      await _insertNotation(
+        db,
+        id: 'n2',
+        title: 'Deleted Raag',
+        deletedAt: '11:00:00',
+      );
+
+      final ids = await service.search('');
+      expect(ids, equals(['n1']));
+    });
+
+    test(
+        'empty query returns IDs ordered by updated_at DESC '
+        '(most-recently updated first)', () async {
+      await _insertNotation(db, id: 'n1', updatedAt: '10:00:00');
+      await _insertNotation(db, id: 'n2', updatedAt: '12:00:00');
+      await _insertNotation(db, id: 'n3', updatedAt: '11:00:00');
+
+      final ids = await service.search('');
+
+      expect(ids, equals(['n2', 'n3', 'n1']));
+    });
+
+    test('empty query with limit restricts number of returned IDs', () async {
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(db, id: 'n$i', title: 'Raag $i');
+      }
+
+      final ids = await service.search('', limit: 3);
+      expect(ids, hasLength(3));
+    });
+
+    test('empty query with offset skips leading results', () async {
+      // Insert with distinct updatedAt so ordering is deterministic.
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(
+          db,
+          id: 'n$i',
+          updatedAt: '${10 + i}:00:00',
+        );
+      }
+
+      final all = await service.search('');
+      final paged = await service.search('', limit: 5, offset: 2);
+
+      expect(paged, equals(all.sublist(2)));
+    });
+
+    test('empty query pages are non-overlapping', () async {
+      for (var i = 0; i < 6; i++) {
+        await _insertNotation(
+          db,
+          id: 'n$i',
+          updatedAt: '${10 + i}:00:00',
+        );
+      }
+
+      final page1 = await service.search('', limit: 3, offset: 0);
+      final page2 = await service.search('', limit: 3, offset: 3);
+
+      expect(page1.toSet().intersection(page2.toSet()), isEmpty);
+      expect(<String>{...page1, ...page2}, hasLength(6));
+    });
+  });
+
+  group('SearchService.search — non-empty query', () {
+    late AppDatabase db;
+    late SearchService service;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+      service = SearchService(db: db, ftsDao: FtsDao(db));
+    });
+    tearDown(() => db.close());
+
+    test('returns matching notation ID by title', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairavi Raag');
+
+      final ids = await service.search('Bhairavi');
+      expect(ids, equals(['n1']));
+    });
+
+    test('prefix matching: "Bhai" matches notation titled "Bhairavi"',
+        () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairavi Raag');
+
+      final ids = await service.search('Bhai');
+      expect(ids, contains('n1'));
+    });
+
+    test('returns only IDs (strings), not full rows', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairavi');
+
+      final ids = await service.search('Bhai');
+      expect(ids, isA<List<String>>());
+    });
+
+    test('returns empty list when no notation matches', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+
+      final ids = await service.search('Todi');
+      expect(ids, isEmpty);
+    });
+
+    test('excludes soft-deleted notations', () async {
+      await _insertNotation(db, id: 'n1', title: 'Raag Active');
+      await _insertNotation(
+        db,
+        id: 'n2',
+        title: 'Raag Deleted',
+        deletedAt: '11:00:00',
+      );
+
+      final ids = await service.search('Raag');
+      expect(ids, equals(['n1']));
+    });
+
+    test('limit restricts the number of returned IDs', () async {
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(db, id: 'n$i', title: 'Raag Number $i');
+      }
+
+      final ids = await service.search('Raag', limit: 3);
+      expect(ids, hasLength(3));
+    });
+
+    test('offset skips leading results', () async {
+      for (var i = 0; i < 5; i++) {
+        await _insertNotation(db, id: 'n$i', title: 'Raag Number $i');
+      }
+
+      final all = await service.search('Raag', limit: 5, offset: 0);
+      final paged = await service.search('Raag', limit: 5, offset: 2);
+
+      expect(paged, hasLength(all.length - 2));
+      expect(paged.first, equals(all[2]));
+    });
+
+    test('paginated results have no duplicates across pages', () async {
+      for (var i = 0; i < 6; i++) {
+        await _insertNotation(db, id: 'n$i', title: 'Raag Item $i');
+      }
+
+      final page1 = await service.search('Raag', limit: 3, offset: 0);
+      final page2 = await service.search('Raag', limit: 3, offset: 3);
+
+      expect(page1.toSet().intersection(page2.toSet()), isEmpty);
+      expect(<String>{...page1, ...page2}, hasLength(6));
+    });
+
+    test('matches by artists field', () async {
+      await _insertNotation(
+        db,
+        id: 'n1',
+        title: 'Morning Raga',
+        artists: '["Bismillah Khan"]',
+      );
+
+      final ids = await service.search('Bismil');
+      expect(ids, contains('n1'));
+    });
+
+    test('matches by notes field', () async {
+      await _insertNotation(
+        db,
+        id: 'n1',
+        title: 'Evening Raga',
+        notes: 'Monsoon season composition',
+      );
+
+      final ids = await service.search('Monsoon');
+      expect(ids, contains('n1'));
+    });
+  });
+
+  group('SearchService.reindexAll', () {
+    late AppDatabase db;
+    late SearchService service;
+
+    setUp(() async {
+      db = AppDatabase.forTesting();
+      await db.customSelect('SELECT 1').getSingle();
+      await db.createFtsSchema();
+      service = SearchService(db: db, ftsDao: FtsDao(db));
+    });
+    tearDown(() => db.close());
+
+    test('reindexAll completes without throwing', () async {
+      await _insertNotation(db, id: 'n1', title: 'Bhairav');
+      await expectLater(service.reindexAll(), completes);
+    });
+
+    test('after reindexAll, existing notations are still findable via search',
+        () async {
+      await _insertNotation(db, id: 'n1', title: 'Darbari Kanada');
+
+      await service.reindexAll();
+
+      final ids = await service.search('Darbari');
+      expect(ids, contains('n1'));
+    });
+
+    test('after reindexAll, notations inserted after the rebuild are findable',
+        () async {
+      // Insert a row before reindex.
+      await _insertNotation(db, id: 'n1', title: 'Puriya Dhanashri');
+
+      await service.reindexAll();
+
+      // Insert a row after reindex.
+      await _insertNotation(db, id: 'n2', title: 'Bhimpalasi');
+
+      final ids = await service.search('Bhimpal');
+      expect(ids, contains('n2'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Closes #74

## Summary
- Implements `SearchService` in `lib/core/search/search_service.dart` with `search()` and `reindexAll()` methods
- `search(query)` returns `List<String>` (notation IDs only): empty/whitespace query returns all active IDs ordered by `updated_at DESC`; non-empty query delegates to `FtsDao` for BM25-ranked FTS5 prefix-matching
- `reindexAll()` drops and recreates the FTS5 virtual table + triggers, then issues `INSERT INTO notations_fts(notations_fts) VALUES('rebuild')` to repopulate the content-table-backed index
- 20 unit tests cover all branches: empty/whitespace query, FTS prefix match, pagination, soft-delete exclusion, and reindex correctness

## Type of Change
- [x] feat — new capability

## Commit Convention
`feat(search): implement SearchService with FTS5 BM25 query (#74)`

## Test Plan
- [x] Unit tests written: `test/unit/core/search/search_service_test.dart` — 20 tests
- [x] `flutter test` passes: 446/446 tests pass
- [x] Coverage: 100% on new business logic files
- [x] `flutter analyze --fatal-infos --fatal-warnings` clean — zero warnings
- [x] `dart format` applied

## Screenshots / Recordings
N/A — no UI change

## Checklist
- [x] No `print` statements (uses `dart:developer` `log`)
- [x] No relative imports — `package:` imports only
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] No generated files needed (no code generation)
- [x] No hardcoded secrets