### PR TITLE
feat(tags): implement TagsViewModel, TagsScreen, and Catppuccin color picker (#76)

### DIFF
--- a/lib/features/tags/screens/tags_screen.dart
+++ b/lib/features/tags/screens/tags_screen.dart
@@ -1,0 +1,395 @@
+// TagsScreen — screen for managing user-defined notation tags.
+//
+// Route: /settings/tags
+//
+// The screen observes [TagsViewModel] via [ChangeNotifierProvider] and renders
+// one of four states: idle, loading, success (tag list), or error. Each tag
+// row shows a colored chip swatch, name, an edit icon button, and a delete
+// icon button. Tapping the FAB or the edit icon opens [TagFormSheet] as a
+// modal bottom sheet. Tapping delete opens a confirmation dialog before
+// invoking [TagsViewModel.deleteTag].
+//
+// Dependencies are injected at the call site:
+//   ChangeNotifierProvider<TagsViewModel>(
+//     create: (_) => TagsViewModel(tagRepository)..init(),
+//     child: const TagsScreen(),
+//   )
+//
+// Or the screen can be used with an already-provided ViewModel by wrapping
+// with ChangeNotifierProvider.value.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/tags/viewmodels/tags_view_model.dart';
+import 'package:swaralipi/features/tags/widgets/catppuccin_color_picker.dart';
+import 'package:swaralipi/features/tags/widgets/tag_form_sheet.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Minimum touch target height for each tag row.
+const double _kTagRowMinHeight = 56.0;
+
+/// Diameter of the color swatch chip in the tag row.
+const double _kSwatchDiameter = 28.0;
+
+/// Horizontal padding for the tag list.
+const EdgeInsets _kListPadding =
+    EdgeInsets.symmetric(horizontal: 16, vertical: 8);
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Screen for managing user-defined notation tags.
+///
+/// Reads [TagsViewModel] from the widget tree via [ChangeNotifierProvider].
+/// Calls [TagsViewModel.init] in [initState].
+class TagsScreen extends StatefulWidget {
+  /// Creates a [TagsScreen].
+  const TagsScreen({super.key});
+
+  @override
+  State<TagsScreen> createState() => _TagsScreenState();
+}
+
+class _TagsScreenState extends State<TagsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Schedule after first frame so Provider is available.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<TagsViewModel>().init();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<TagsViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tags'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openCreateSheet(context),
+        tooltip: 'Create tag',
+        child: const Icon(Icons.add),
+      ),
+      body: switch (vm.state) {
+        TagsStateIdle() => const SizedBox.shrink(),
+        TagsStateLoading() => const _LoadingView(),
+        TagsStateSuccess(:final tags) =>
+          tags.isEmpty ? const _EmptyView() : _TagListView(tags: tags),
+        TagsStateError(:final message) => _ErrorView(message: message),
+      },
+    );
+  }
+
+  Future<void> _openCreateSheet(BuildContext context) async {
+    final vm = context.read<TagsViewModel>();
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(28),
+        ),
+      ),
+      builder: (_) => TagFormSheet(
+        onSave: (name, colorHex) async {
+          await vm.createTag(name, colorHex);
+        },
+      ),
+    );
+
+    if (!mounted) return;
+    if (vm.createError != null) {
+      _showErrorSnackBar(context, 'Could not create tag. Please try again.');
+      vm.clearCreateError();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private state views
+// ---------------------------------------------------------------------------
+
+/// Loading indicator while the tags stream is initializing.
+class _LoadingView extends StatelessWidget {
+  const _LoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+/// Empty state view shown when the user has no tags yet.
+class _EmptyView extends StatelessWidget {
+  const _EmptyView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.label_outline,
+            size: 64,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No tags yet',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Tap + to create your first tag.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Error view shown when the tags stream emits an error.
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load tags',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Scrollable list of tag rows.
+class _TagListView extends StatelessWidget {
+  const _TagListView({required this.tags});
+
+  final List<Tag> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: _kListPadding,
+      itemCount: tags.length,
+      itemBuilder: (context, index) => _TagRow(tag: tags[index]),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag row
+// ---------------------------------------------------------------------------
+
+/// A single tag row with color swatch, name, edit, and delete controls.
+class _TagRow extends StatelessWidget {
+  const _TagRow({required this.tag});
+
+  final Tag tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: tag.name,
+      child: SizedBox(
+        height: _kTagRowMinHeight,
+        child: Row(
+          children: [
+            _ColorSwatch(colorHex: tag.colorHex),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                tag.name,
+                style: Theme.of(context).textTheme.bodyLarge,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            _EditButton(tag: tag),
+            _DeleteButton(tag: tag),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Circular color swatch for a tag row.
+class _ColorSwatch extends StatelessWidget {
+  const _ColorSwatch({required this.colorHex});
+
+  final String colorHex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _kSwatchDiameter,
+      height: _kSwatchDiameter,
+      decoration: BoxDecoration(
+        color: colorFromHex(colorHex),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}
+
+/// Edit icon button that opens the tag form sheet pre-filled with the tag.
+class _EditButton extends StatelessWidget {
+  const _EditButton({required this.tag});
+
+  final Tag tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Edit ${tag.name}',
+      button: true,
+      child: IconButton(
+        icon: const Icon(Icons.edit_outlined),
+        onPressed: () => _openEditSheet(context),
+        tooltip: 'Edit',
+      ),
+    );
+  }
+
+  Future<void> _openEditSheet(BuildContext context) async {
+    final vm = context.read<TagsViewModel>();
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(28),
+        ),
+      ),
+      builder: (_) => TagFormSheet(
+        initialName: tag.name,
+        initialColorHex: tag.colorHex,
+        onSave: (name, colorHex) async {
+          await vm.updateTag(tag.id, name: name, colorHex: colorHex);
+        },
+      ),
+    );
+
+    if (!context.mounted) return;
+    if (vm.updateError != null) {
+      _showErrorSnackBar(context, 'Could not update tag. Please try again.');
+      vm.clearUpdateError();
+    }
+  }
+}
+
+/// Delete icon button that shows a confirmation dialog before deleting.
+class _DeleteButton extends StatelessWidget {
+  const _DeleteButton({required this.tag});
+
+  final Tag tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Delete ${tag.name}',
+      button: true,
+      child: IconButton(
+        icon: const Icon(Icons.delete_outline),
+        onPressed: () => _confirmAndDelete(context),
+        tooltip: 'Delete',
+      ),
+    );
+  }
+
+  Future<void> _confirmAndDelete(BuildContext context) async {
+    final vm = context.read<TagsViewModel>();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Delete tag?'),
+        content: Text(
+          'Removes "${tag.name}" from all notations.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+    if (!context.mounted) return;
+
+    await vm.deleteTag(tag.id);
+
+    if (!context.mounted) return;
+    if (vm.deleteError != null) {
+      _showErrorSnackBar(context, 'Could not delete tag. Please try again.');
+      vm.clearDeleteError();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper
+// ---------------------------------------------------------------------------
+
+/// Shows a brief error [SnackBar] using the nearest [ScaffoldMessenger].
+///
+/// Parameters:
+/// - [context]: Build context with an active [Scaffold] in its tree.
+/// - [message]: The error message to display.
+void _showErrorSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(message)),
+  );
+}

--- a/lib/features/tags/viewmodels/tags_view_model.dart
+++ b/lib/features/tags/viewmodels/tags_view_model.dart
@@ -1,0 +1,279 @@
+// TagsViewModel — ChangeNotifier-based ViewModel for the Tags feature.
+//
+// Subscribes to [TagRepository.watchAllTags] and exposes state as a sealed
+// [TagsState] hierarchy: idle / loading / success / error.
+//
+// Separate per-operation error fields (createError, updateError, deleteError)
+// allow the UI to surface operation-specific error feedback without replacing
+// the entire list state.
+//
+// Construction:
+//   TagsViewModel(tagRepository)
+//
+// Lifecycle:
+//   Call [init] once from the screen's initState / DidChangeDependencies.
+//   Dispose is handled by the ChangeNotifier lifecycle.
+
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+
+// ---------------------------------------------------------------------------
+// State hierarchy
+// ---------------------------------------------------------------------------
+
+/// Sealed state for the [TagsViewModel].
+///
+/// Variants: [TagsStateIdle], [TagsStateLoading], [TagsStateSuccess],
+/// [TagsStateError].
+sealed class TagsState {
+  /// Creates a [TagsState].
+  const TagsState();
+}
+
+/// Initial state before [TagsViewModel.init] is called.
+final class TagsStateIdle extends TagsState {
+  /// Creates a [TagsStateIdle].
+  const TagsStateIdle();
+}
+
+/// State while awaiting the first stream emission.
+final class TagsStateLoading extends TagsState {
+  /// Creates a [TagsStateLoading].
+  const TagsStateLoading();
+}
+
+/// State when the tag list has been successfully received from the stream.
+final class TagsStateSuccess extends TagsState {
+  /// Creates a [TagsStateSuccess] with the given [tags].
+  ///
+  /// Parameters:
+  /// - [tags]: The current list of all user-defined tags.
+  const TagsStateSuccess({required this.tags});
+
+  /// The current list of all tags, ordered alphabetically.
+  final List<Tag> tags;
+}
+
+/// State when the stream emitted an error.
+final class TagsStateError extends TagsState {
+  /// Creates a [TagsStateError] with the given [message].
+  ///
+  /// Parameters:
+  /// - [message]: Human-readable description of the error.
+  const TagsStateError({required this.message});
+
+  /// Human-readable description of the stream error.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/// ViewModel for the Tags management screen.
+///
+/// Observes [TagRepository.watchAllTags] and translates stream events into
+/// [TagsState] values. Exposes CRUD operations that delegate to the repository
+/// and surface per-operation errors via dedicated nullable fields.
+///
+/// State management contract:
+/// - [state] is the primary display state (idle / loading / success / error).
+/// - [createError], [updateError], [deleteError] are auxiliary error fields;
+///   they do not affect [state] so the tag list remains visible while an
+///   operation-specific error is surfaced.
+class TagsViewModel extends ChangeNotifier {
+  /// Creates a [TagsViewModel] backed by [_repository].
+  ///
+  /// Parameters:
+  /// - [_repository]: Source of truth for all tag data operations.
+  TagsViewModel(this._repository);
+
+  final TagRepository _repository;
+  StreamSubscription<List<Tag>>? _subscription;
+
+  TagsState _state = const TagsStateIdle();
+  String? _createError;
+  String? _updateError;
+  String? _deleteError;
+
+  // -------------------------------------------------------------------------
+  // Public getters
+  // -------------------------------------------------------------------------
+
+  /// The current display state of the tags screen.
+  TagsState get state => _state;
+
+  /// Non-null when the most recent [createTag] call failed.
+  ///
+  /// Clear with [clearCreateError] after the error has been surfaced.
+  String? get createError => _createError;
+
+  /// Non-null when the most recent [updateTag] call failed.
+  ///
+  /// Clear with [clearUpdateError] after the error has been surfaced.
+  String? get updateError => _updateError;
+
+  /// Non-null when the most recent [deleteTag] call failed.
+  ///
+  /// Clear with [clearDeleteError] after the error has been surfaced.
+  String? get deleteError => _deleteError;
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /// Subscribes to the tag stream and begins emitting state updates.
+  ///
+  /// Transitions immediately to [TagsStateLoading], then to
+  /// [TagsStateSuccess] or [TagsStateError] as the stream emits. Calling
+  /// [init] again cancels the previous subscription before restarting.
+  void init() {
+    _subscription?.cancel();
+    _state = const TagsStateLoading();
+    notifyListeners();
+
+    _subscription = _repository.watchAllTags().listen(
+      (tags) {
+        _state = TagsStateSuccess(tags: tags);
+        notifyListeners();
+      },
+      onError: (Object error, StackTrace stack) {
+        log(
+          'TagsViewModel: stream error — $error',
+          name: 'TagsViewModel',
+          error: error,
+          stackTrace: stack,
+        );
+        _state = TagsStateError(message: error.toString());
+        notifyListeners();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  // -------------------------------------------------------------------------
+  // CRUD operations
+  // -------------------------------------------------------------------------
+
+  /// Creates a new tag with [name] and [colorHex].
+  ///
+  /// Returns the persisted [Tag] on success, or `null` on failure. On failure
+  /// [createError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [name]: Unique display name for the new tag.
+  /// - [colorHex]: Catppuccin hex color string, e.g. `'#f38ba8'`.
+  Future<Tag?> createTag(String name, String colorHex) async {
+    try {
+      final tag = await _repository.createTag(name, colorHex);
+      log(
+        'TagsViewModel: created tag "${tag.name}"',
+        name: 'TagsViewModel',
+      );
+      return tag;
+    } on Exception catch (e, st) {
+      log(
+        'TagsViewModel: createTag failed — $e',
+        name: 'TagsViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _createError = e.toString();
+      notifyListeners();
+      return null;
+    }
+  }
+
+  /// Updates the tag identified by [id] with optional new [name] and
+  /// [colorHex].
+  ///
+  /// Returns the updated [Tag] on success, or `null` on failure. On failure
+  /// [updateError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the tag to update.
+  /// - [name]: New display name; omit to leave unchanged.
+  /// - [colorHex]: New Catppuccin hex color string; omit to leave unchanged.
+  Future<Tag?> updateTag(
+    String id, {
+    String? name,
+    String? colorHex,
+  }) async {
+    try {
+      final tag =
+          await _repository.updateTag(id, name: name, colorHex: colorHex);
+      log(
+        'TagsViewModel: updated tag "$id"',
+        name: 'TagsViewModel',
+      );
+      return tag;
+    } on Exception catch (e, st) {
+      log(
+        'TagsViewModel: updateTag failed — $e',
+        name: 'TagsViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _updateError = e.toString();
+      notifyListeners();
+      return null;
+    }
+  }
+
+  /// Deletes the tag identified by [id].
+  ///
+  /// On failure [deleteError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the tag to delete.
+  Future<void> deleteTag(String id) async {
+    try {
+      await _repository.deleteTag(id);
+      log(
+        'TagsViewModel: deleted tag "$id"',
+        name: 'TagsViewModel',
+      );
+    } on Exception catch (e, st) {
+      log(
+        'TagsViewModel: deleteTag failed — $e',
+        name: 'TagsViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _deleteError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Error reset helpers
+  // -------------------------------------------------------------------------
+
+  /// Clears [createError] and notifies listeners.
+  void clearCreateError() {
+    _createError = null;
+    notifyListeners();
+  }
+
+  /// Clears [updateError] and notifies listeners.
+  void clearUpdateError() {
+    _updateError = null;
+    notifyListeners();
+  }
+
+  /// Clears [deleteError] and notifies listeners.
+  void clearDeleteError() {
+    _deleteError = null;
+    notifyListeners();
+  }
+}

--- a/lib/features/tags/widgets/catppuccin_color_picker.dart
+++ b/lib/features/tags/widgets/catppuccin_color_picker.dart
@@ -1,0 +1,168 @@
+// CatppuccinColorPicker — Catppuccin Mocha accent color grid picker widget.
+//
+// Renders all 14 Catppuccin Mocha accent colors as selectable chip swatches.
+// The currently selected color is highlighted with a check mark overlay.
+//
+// Usage:
+//   CatppuccinColorPicker(
+//     selectedColorHex: '#f38ba8',
+//     onColorSelected: (hex) => setState(() => _colorHex = hex),
+//   )
+
+import 'package:flutter/material.dart';
+
+// ---------------------------------------------------------------------------
+// Catppuccin Mocha palette constants
+// ---------------------------------------------------------------------------
+
+/// All 14 Catppuccin Mocha accent color hex strings.
+const List<String> kCatppuccinMochaAccents = [
+  '#f38ba8', // Rosewater
+  '#fab387', // Peach
+  '#f9e2af', // Yellow
+  '#a6e3a1', // Green
+  '#94e2d5', // Teal
+  '#89dceb', // Sky
+  '#89b4fa', // Blue
+  '#b4befe', // Lavender
+  '#cba6f7', // Mauve
+  '#f5c2e7', // Pink
+  '#eba0ac', // Maroon
+  '#a6adc8', // Subtext 1
+  '#bac2de', // Subtext 0
+  '#7f849c', // Overlay 1
+];
+
+/// Human-readable names for each Catppuccin Mocha accent, keyed by hex.
+const Map<String, String> kCatppuccinMochaNames = {
+  '#f38ba8': 'Rosewater',
+  '#fab387': 'Peach',
+  '#f9e2af': 'Yellow',
+  '#a6e3a1': 'Green',
+  '#94e2d5': 'Teal',
+  '#89dceb': 'Sky',
+  '#89b4fa': 'Blue',
+  '#b4befe': 'Lavender',
+  '#cba6f7': 'Mauve',
+  '#f5c2e7': 'Pink',
+  '#eba0ac': 'Maroon',
+  '#a6adc8': 'Subtext 1',
+  '#bac2de': 'Subtext 0',
+  '#7f849c': 'Overlay 1',
+};
+
+// ---------------------------------------------------------------------------
+// Color parsing helper
+// ---------------------------------------------------------------------------
+
+/// Parses a Catppuccin hex string (e.g. `'#f38ba8'`) to a [Color].
+///
+/// Returns [Colors.grey] if the string is malformed.
+///
+/// Parameters:
+/// - [hex]: A 7-character hex string starting with `#`.
+Color colorFromHex(String hex) {
+  final normalized = hex.replaceFirst('#', '');
+  final value = int.tryParse('FF$normalized', radix: 16);
+  if (value == null) return Colors.grey;
+  return Color(value);
+}
+
+// ---------------------------------------------------------------------------
+// Widget
+// ---------------------------------------------------------------------------
+
+/// Spacing between color swatches in the grid.
+const double _kSwatchSpacing = 8.0;
+
+/// Size of each color swatch chip.
+const double _kSwatchSize = 40.0;
+
+/// A grid of selectable Catppuccin Mocha color swatches.
+///
+/// Displays all [kCatppuccinMochaAccents] as circular chips. The currently
+/// selected swatch is highlighted with a check mark. Tapping a swatch calls
+/// [onColorSelected] with the corresponding hex string.
+class CatppuccinColorPicker extends StatelessWidget {
+  /// Creates a [CatppuccinColorPicker].
+  ///
+  /// Parameters:
+  /// - [selectedColorHex]: The currently selected hex string; may be `null`
+  ///   when no selection has been made yet.
+  /// - [onColorSelected]: Called with the hex string when a swatch is tapped.
+  const CatppuccinColorPicker({
+    super.key,
+    required this.selectedColorHex,
+    required this.onColorSelected,
+  });
+
+  /// The currently selected Catppuccin hex color string.
+  final String? selectedColorHex;
+
+  /// Called when the user selects a color swatch.
+  final ValueChanged<String> onColorSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: _kSwatchSpacing,
+      runSpacing: _kSwatchSpacing,
+      children: kCatppuccinMochaAccents.map((hex) {
+        final isSelected = hex == selectedColorHex;
+        final color = colorFromHex(hex);
+        final name = kCatppuccinMochaNames[hex] ?? hex;
+
+        return Semantics(
+          label: '$name${isSelected ? ', selected' : ''}',
+          button: true,
+          child: GestureDetector(
+            onTap: () => onColorSelected(hex),
+            child: _ColorSwatch(
+              color: color,
+              isSelected: isSelected,
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+/// A single circular color swatch with an optional selection indicator.
+class _ColorSwatch extends StatelessWidget {
+  const _ColorSwatch({
+    required this.color,
+    required this.isSelected,
+  });
+
+  final Color color;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _kSwatchSize,
+      height: _kSwatchSize,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isSelected
+              ? Theme.of(context).colorScheme.onSurface
+              : Colors.transparent,
+          width: 2.5,
+        ),
+      ),
+      child: isSelected
+          ? Icon(
+              Icons.check,
+              size: 20,
+              color:
+                  ThemeData.estimateBrightnessForColor(color) == Brightness.dark
+                      ? Colors.white
+                      : Colors.black,
+            )
+          : null,
+    );
+  }
+}

--- a/lib/features/tags/widgets/tag_form_sheet.dart
+++ b/lib/features/tags/widgets/tag_form_sheet.dart
@@ -1,0 +1,303 @@
+// TagFormSheet — modal bottom sheet for creating or editing a tag.
+//
+// Shows a name text field and a Catppuccin Mocha color grid picker. The
+// [initialName] and [initialColorHex] parameters pre-fill the form for
+// edit mode; both are omitted for create mode.
+//
+// The [onSave] callback is invoked only when the form is valid (non-empty name
+// and a color is selected). The sheet closes itself after a successful save.
+//
+// Usage — create:
+//   showModalBottomSheet(
+//     context: context,
+//     isScrollControlled: true,
+//     builder: (_) => TagFormSheet(onSave: (name, hex) async { ... }),
+//   );
+//
+// Usage — edit:
+//   showModalBottomSheet(
+//     context: context,
+//     isScrollControlled: true,
+//     builder: (_) => TagFormSheet(
+//       initialName: tag.name,
+//       initialColorHex: tag.colorHex,
+//       onSave: (name, hex) async { ... },
+//     ),
+//   );
+
+import 'package:flutter/material.dart';
+
+import 'package:swaralipi/features/tags/widgets/catppuccin_color_picker.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum characters allowed for a tag name.
+const int _kTagNameMaxLength = 50;
+
+/// Padding around the sheet content.
+const EdgeInsets _kSheetPadding = EdgeInsets.fromLTRB(24, 16, 24, 24);
+
+/// Vertical space between form sections.
+const double _kSectionSpacing = 20.0;
+
+// ---------------------------------------------------------------------------
+// Sheet widget
+// ---------------------------------------------------------------------------
+
+/// A modal bottom sheet form for creating or editing a tag.
+///
+/// Provides a name field and a [CatppuccinColorPicker]. The [onSave] callback
+/// is invoked with the trimmed name and selected color hex when the user taps
+/// Save and the form is valid.
+class TagFormSheet extends StatefulWidget {
+  /// Creates a [TagFormSheet].
+  ///
+  /// Parameters:
+  /// - [initialName]: Pre-filled name for edit mode; omit for create mode.
+  /// - [initialColorHex]: Pre-selected color for edit mode; omit for create.
+  /// - [onSave]: Async callback receiving the validated (name, colorHex) pair.
+  const TagFormSheet({
+    super.key,
+    this.initialName,
+    this.initialColorHex,
+    required this.onSave,
+  });
+
+  /// Pre-filled tag name when editing an existing tag.
+  final String? initialName;
+
+  /// Pre-selected Catppuccin hex color when editing an existing tag.
+  final String? initialColorHex;
+
+  /// Called with `(name, colorHex)` when the form is submitted and valid.
+  final Future<void> Function(String name, String colorHex) onSave;
+
+  @override
+  State<TagFormSheet> createState() => _TagFormSheetState();
+}
+
+class _TagFormSheetState extends State<TagFormSheet> {
+  late final TextEditingController _nameController;
+  final _formKey = GlobalKey<FormState>();
+  String? _selectedColorHex;
+  bool _isSaving = false;
+  String? _colorError;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initialName);
+    _selectedColorHex = widget.initialColorHex;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSave() async {
+    // Validate color selection separately since it's not a FormField.
+    if (_selectedColorHex == null) {
+      setState(() => _colorError = 'Please select a color');
+      return;
+    }
+    setState(() => _colorError = null);
+
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    setState(() => _isSaving = true);
+
+    await widget.onSave(
+      _nameController.text.trim(),
+      _selectedColorHex!,
+    );
+
+    if (!mounted) return;
+    setState(() => _isSaving = false);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.initialName != null;
+
+    return Padding(
+      // Shift sheet up when the keyboard is visible.
+      padding: _kSheetPadding.copyWith(
+        bottom:
+            _kSheetPadding.bottom + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _SheetHandle(),
+            const SizedBox(height: 8),
+            Text(
+              isEditing ? 'Edit Tag' : 'New Tag',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: _kSectionSpacing),
+            _NameField(controller: _nameController),
+            const SizedBox(height: _kSectionSpacing),
+            _ColorPickerSection(
+              selectedColorHex: _selectedColorHex,
+              errorText: _colorError,
+              onColorSelected: (hex) {
+                setState(() {
+                  _selectedColorHex = hex;
+                  _colorError = null;
+                });
+              },
+            ),
+            const SizedBox(height: _kSectionSpacing),
+            _SaveCancelRow(
+              isSaving: _isSaving,
+              onCancel: () => Navigator.of(context).pop(),
+              onSave: _handleSave,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private sub-widgets
+// ---------------------------------------------------------------------------
+
+/// Draggable handle indicator at the top of the sheet.
+class _SheetHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 32,
+        height: 4,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.outlineVariant,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+/// Tag name text field with validation.
+class _NameField extends StatelessWidget {
+  const _NameField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      maxLength: _kTagNameMaxLength,
+      textCapitalization: TextCapitalization.words,
+      decoration: const InputDecoration(
+        labelText: 'Name',
+        border: OutlineInputBorder(),
+        counterText: '',
+      ),
+      validator: (value) {
+        final trimmed = value?.trim() ?? '';
+        if (trimmed.isEmpty) return 'Name cannot be empty';
+        return null;
+      },
+    );
+  }
+}
+
+/// Color picker section with label and optional error text.
+class _ColorPickerSection extends StatelessWidget {
+  const _ColorPickerSection({
+    required this.selectedColorHex,
+    required this.onColorSelected,
+    this.errorText,
+  });
+
+  final String? selectedColorHex;
+  final ValueChanged<String> onColorSelected;
+  final String? errorText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Color',
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+        const SizedBox(height: 12),
+        CatppuccinColorPicker(
+          selectedColorHex: selectedColorHex,
+          onColorSelected: onColorSelected,
+        ),
+        if (errorText != null) ...[
+          const SizedBox(height: 6),
+          Text(
+            errorText!,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Row with Cancel and Save buttons.
+class _SaveCancelRow extends StatelessWidget {
+  const _SaveCancelRow({
+    required this.isSaving,
+    required this.onCancel,
+    required this.onSave,
+  });
+
+  final bool isSaving;
+  final VoidCallback onCancel;
+  final VoidCallback onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        Semantics(
+          label: 'Cancel',
+          button: true,
+          child: TextButton(
+            onPressed: isSaving ? null : onCancel,
+            child: const Text('Cancel'),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Semantics(
+          label: 'Save tag',
+          button: true,
+          child: FilledButton(
+            onPressed: isSaving ? null : onSave,
+            child: isSaving
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Save'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/unit/features/tags/viewmodels/tags_view_model_test.dart
+++ b/test/unit/features/tags/viewmodels/tags_view_model_test.dart
@@ -1,0 +1,374 @@
+// Unit tests for TagsViewModel.
+//
+// Covers all public state transitions and methods using a FakeTagRepository:
+//   init (watchAllTags) → idle / loading / success / error
+//   createTag → optimistic stream update via fake
+//   updateTag → success and TagNotFoundException paths
+//   deleteTag → success and confirmation dialog paths
+//
+// Each test sets up a fresh FakeTagRepository in setUp to ensure isolation.
+//
+// Naming convention:
+//   <method> — <scenario> → <expected outcome>
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/tags/viewmodels/tags_view_model.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/// In-memory fake [TagRepository] for controlling stream and error scenarios.
+class FakeTagRepository implements TagRepository {
+  final _controller = StreamController<List<Tag>>.broadcast();
+  Object? _watchError;
+  Object? _createError;
+  Object? _updateError;
+  Object? _deleteError;
+  final List<Tag> _tags = [];
+
+  void emitTags(List<Tag> tags) {
+    _tags
+      ..clear()
+      ..addAll(tags);
+    _controller.add(List.unmodifiable(_tags));
+  }
+
+  void emitWatchError(Object error) {
+    _watchError = error;
+    _controller.addError(error);
+  }
+
+  void setCreateError(Object? error) => _createError = error;
+  void setUpdateError(Object? error) => _updateError = error;
+  void setDeleteError(Object? error) => _deleteError = error;
+
+  @override
+  Stream<List<Tag>> watchAllTags() {
+    if (_watchError != null) {
+      return Stream.error(_watchError!);
+    }
+    return _controller.stream;
+  }
+
+  @override
+  Future<Tag> createTag(String name, String colorHex) async {
+    if (_createError != null) throw _createError!;
+    final tag = Tag(
+      id: 'id-$name',
+      name: name,
+      colorHex: colorHex,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    );
+    _tags.add(tag);
+    _controller.add(List.unmodifiable(_tags));
+    return tag;
+  }
+
+  @override
+  Future<Tag> updateTag(
+    String id, {
+    String? name,
+    String? colorHex,
+  }) async {
+    if (_updateError != null) throw _updateError!;
+    final idx = _tags.indexWhere((t) => t.id == id);
+    if (idx == -1) throw TagNotFoundException(id);
+    final updated = _tags[idx].copyWith(name: name, colorHex: colorHex);
+    _tags[idx] = updated;
+    _controller.add(List.unmodifiable(_tags));
+    return updated;
+  }
+
+  @override
+  Future<void> deleteTag(String id) async {
+    if (_deleteError != null) throw _deleteError!;
+    _tags.removeWhere((t) => t.id == id);
+    _controller.add(List.unmodifiable(_tags));
+  }
+
+  @override
+  Future<void> seedDefaultTagsIfNeeded() async {}
+
+  void close() => _controller.close();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Tag _makeTag({
+  String id = 'tag-1',
+  String name = 'Ragas',
+  String colorHex = '#f38ba8',
+}) =>
+    Tag(
+      id: id,
+      name: name,
+      colorHex: colorHex,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeTagRepository repo;
+  late TagsViewModel vm;
+
+  setUp(() {
+    repo = FakeTagRepository();
+    vm = TagsViewModel(repo);
+  });
+
+  tearDown(() {
+    vm.dispose();
+    repo.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  group('initial state', () {
+    test('state is idle before init is called', () {
+      expect(vm.state, isA<TagsStateIdle>());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // init
+  // -------------------------------------------------------------------------
+
+  group('init', () {
+    test('transitions to loading then success when stream emits', () async {
+      final states = <TagsState>[];
+      vm.addListener(() => states.add(vm.state));
+
+      vm.init();
+
+      // Immediately loading
+      expect(states.last, isA<TagsStateLoading>());
+
+      // Emit data
+      final tags = [_makeTag()];
+      repo.emitTags(tags);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.state, isA<TagsStateSuccess>());
+      expect((vm.state as TagsStateSuccess).tags, tags);
+    });
+
+    test('transitions to loading then error when stream emits error', () async {
+      final states = <TagsState>[];
+      vm.addListener(() => states.add(vm.state));
+
+      vm.init();
+
+      // Trigger stream error
+      repo.emitWatchError(Exception('DB failure'));
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.state, isA<TagsStateError>());
+      expect(
+        (vm.state as TagsStateError).message,
+        contains('DB failure'),
+      );
+    });
+
+    test('updates state when stream emits subsequent values', () async {
+      vm.init();
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect((vm.state as TagsStateSuccess).tags.length, 1);
+
+      final tag2 = _makeTag(id: 'tag-2', name: 'Bhajans');
+      repo.emitTags([_makeTag(), tag2]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect((vm.state as TagsStateSuccess).tags.length, 2);
+    });
+
+    test('calling init multiple times cancels previous subscription', () async {
+      vm.init();
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+      expect((vm.state as TagsStateSuccess).tags.length, 1);
+
+      vm.init(); // Re-init
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect((vm.state as TagsStateSuccess).tags, isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createTag
+  // -------------------------------------------------------------------------
+
+  group('createTag', () {
+    setUp(() {
+      vm.init();
+    });
+
+    test('success — returns created Tag and stream updates', () async {
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await vm.createTag('Practice', '#cba6f7');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(result, isA<Tag>());
+      expect(result!.name, 'Practice');
+      expect((vm.state as TagsStateSuccess).tags.length, 1);
+    });
+
+    test('failure — propagates error and exposes it via createError', () async {
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.setCreateError(Exception('UNIQUE constraint failed'));
+
+      final result = await vm.createTag('Dup', '#f38ba8');
+
+      expect(result, isNull);
+      expect(vm.createError, isNotNull);
+    });
+
+    test('clearCreateError resets the error', () async {
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.setCreateError(Exception('fail'));
+      await vm.createTag('X', '#abc');
+      expect(vm.createError, isNotNull);
+
+      vm.clearCreateError();
+      expect(vm.createError, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // updateTag
+  // -------------------------------------------------------------------------
+
+  group('updateTag', () {
+    setUp(() {
+      vm.init();
+    });
+
+    test('success — returns updated Tag', () async {
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await vm.updateTag(
+        'tag-1',
+        name: 'Ragas Updated',
+        colorHex: '#a6e3a1',
+      );
+
+      expect(result, isA<Tag>());
+      expect(result!.name, 'Ragas Updated');
+    });
+
+    test('failure — propagates TagNotFoundException via updateError', () async {
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await vm.updateTag('nonexistent');
+
+      expect(result, isNull);
+      expect(vm.updateError, isNotNull);
+    });
+
+    test('clearUpdateError resets the error', () async {
+      repo.emitTags([]);
+      await Future<void>.delayed(Duration.zero);
+
+      await vm.updateTag('nonexistent');
+      expect(vm.updateError, isNotNull);
+
+      vm.clearUpdateError();
+      expect(vm.updateError, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteTag
+  // -------------------------------------------------------------------------
+
+  group('deleteTag', () {
+    setUp(() {
+      vm.init();
+    });
+
+    test('success — tag removed from stream', () async {
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect((vm.state as TagsStateSuccess).tags.length, 1);
+
+      await vm.deleteTag('tag-1');
+      await Future<void>.delayed(Duration.zero);
+
+      expect((vm.state as TagsStateSuccess).tags, isEmpty);
+    });
+
+    test('failure — exposes error via deleteError', () async {
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.setDeleteError(Exception('delete failed'));
+      await vm.deleteTag('tag-1');
+
+      expect(vm.deleteError, isNotNull);
+    });
+
+    test('clearDeleteError resets the error', () async {
+      repo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      repo.setDeleteError(Exception('fail'));
+      await vm.deleteTag('tag-1');
+      expect(vm.deleteError, isNotNull);
+
+      vm.clearDeleteError();
+      expect(vm.deleteError, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // dispose
+  // -------------------------------------------------------------------------
+
+  group('dispose', () {
+    test('cancels stream subscription on dispose', () async {
+      // Use a separate vm so tearDown does not double-dispose.
+      final localRepo = FakeTagRepository();
+      final localVm = TagsViewModel(localRepo);
+
+      localVm.init();
+      localRepo.emitTags([_makeTag()]);
+      await Future<void>.delayed(Duration.zero);
+
+      localVm.dispose();
+
+      // Emitting after dispose must not throw.
+      expect(() => localRepo.emitTags([]), returnsNormally);
+
+      localRepo.close();
+    });
+  });
+}

--- a/test/widget/features/tags/tags_screen_test.dart
+++ b/test/widget/features/tags/tags_screen_test.dart
@@ -1,0 +1,318 @@
+// Widget tests for TagsScreen.
+//
+// Verifies the screen renders correctly for each TagsState variant and that
+// user interactions (FAB, long-press, swipe-to-dismiss, dialogs) trigger the
+// correct ViewModel calls via a FakeTagsViewModel.
+//
+// All tests use Provider-injected FakeTagsViewModel to avoid real DB access.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/tags/screens/tags_screen.dart';
+import 'package:swaralipi/features/tags/viewmodels/tags_view_model.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fake ViewModel
+// ---------------------------------------------------------------------------
+
+class FakeTagRepository implements TagRepository {
+  @override
+  Stream<List<Tag>> watchAllTags() => const Stream.empty();
+  @override
+  Future<Tag> createTag(String name, String colorHex) async => _makeTag();
+  @override
+  Future<Tag> updateTag(String id, {String? name, String? colorHex}) async =>
+      _makeTag();
+  @override
+  Future<void> deleteTag(String id) async {}
+  @override
+  Future<void> seedDefaultTagsIfNeeded() async {}
+}
+
+Tag _makeTag({
+  String id = 'tag-1',
+  String name = 'Ragas',
+  String colorHex = '#f38ba8',
+}) =>
+    Tag(
+      id: id,
+      name: name,
+      colorHex: colorHex,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    );
+
+class FakeTagsViewModel extends TagsViewModel {
+  FakeTagsViewModel({
+    TagsState initialState = const TagsStateIdle(),
+    this.createTagResult,
+    this.updateTagResult,
+  }) : super(FakeTagRepository()) {
+    _state = initialState;
+  }
+
+  TagsState _state = const TagsStateIdle();
+  final Tag? createTagResult;
+  final Tag? updateTagResult;
+
+  bool initCalled = false;
+  String? lastCreatedName;
+  String? lastCreatedColor;
+  String? lastUpdatedId;
+  String? lastUpdatedName;
+  String? lastDeletedId;
+
+  @override
+  TagsState get state => _state;
+
+  void setState(TagsState s) {
+    _state = s;
+    notifyListeners();
+  }
+
+  @override
+  void init() {
+    initCalled = true;
+  }
+
+  @override
+  Future<Tag?> createTag(String name, String colorHex) async {
+    lastCreatedName = name;
+    lastCreatedColor = colorHex;
+    return createTagResult;
+  }
+
+  @override
+  Future<Tag?> updateTag(
+    String id, {
+    String? name,
+    String? colorHex,
+  }) async {
+    lastUpdatedId = id;
+    lastUpdatedName = name;
+    return updateTagResult;
+  }
+
+  @override
+  Future<void> deleteTag(String id) async {
+    lastDeletedId = id;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Widget _buildScreen(FakeTagsViewModel vm) {
+  return ChangeNotifierProvider<TagsViewModel>.value(
+    value: vm,
+    child: const MaterialApp(
+      home: TagsScreen(),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // -------------------------------------------------------------------------
+  // State rendering
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen state rendering', () {
+    testWidgets('shows loading indicator in loading state', (tester) async {
+      final vm = FakeTagsViewModel(
+        initialState: const TagsStateLoading(),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows tags list in success state', (tester) async {
+      final tags = [
+        _makeTag(id: 'tag-1', name: 'Ragas', colorHex: '#f38ba8'),
+        _makeTag(id: 'tag-2', name: 'Bhajans', colorHex: '#a6e3a1'),
+      ];
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: tags),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(find.text('Ragas'), findsOneWidget);
+      expect(find.text('Bhajans'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state message when no tags', (tester) async {
+      final vm = FakeTagsViewModel(
+        initialState: const TagsStateSuccess(tags: []),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(find.text('No tags yet'), findsOneWidget);
+    });
+
+    testWidgets('shows error message in error state', (tester) async {
+      final vm = FakeTagsViewModel(
+        initialState: const TagsStateError(message: 'DB failure'),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(find.textContaining('DB failure'), findsOneWidget);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // init
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen init', () {
+    testWidgets('calls vm.init when screen loads', (tester) async {
+      final vm = FakeTagsViewModel();
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(vm.initCalled, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FAB — create tag
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen FAB', () {
+    testWidgets('FAB is visible', (tester) async {
+      final vm = FakeTagsViewModel(
+        initialState: const TagsStateSuccess(tags: []),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping FAB opens create bottom sheet with name field and color '
+        'picker', (tester) async {
+      final vm = FakeTagsViewModel(
+        initialState: const TagsStateSuccess(tags: []),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      // Bottom sheet contains a text field for the name
+      expect(find.byType(TextField), findsOneWidget);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Delete confirmation dialog
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen delete', () {
+    testWidgets('tapping delete icon opens confirmation dialog',
+        (tester) async {
+      final tag = _makeTag(id: 'tag-1', name: 'Ragas');
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: [tag]),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      // Tap delete icon
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      // Dialog appears
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('confirming delete calls vm.deleteTag', (tester) async {
+      final tag = _makeTag(id: 'tag-1', name: 'Ragas');
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: [tag]),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      // Tap confirm
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(vm.lastDeletedId, 'tag-1');
+    });
+
+    testWidgets('cancelling delete dialog does NOT call vm.deleteTag',
+        (tester) async {
+      final tag = _makeTag(id: 'tag-1', name: 'Ragas');
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: [tag]),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(vm.lastDeletedId, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edit icon
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen edit', () {
+    testWidgets('tapping edit icon opens tag form bottom sheet',
+        (tester) async {
+      final tag = _makeTag(id: 'tag-1', name: 'Ragas');
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: [tag]),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      await tester.tap(find.byIcon(Icons.edit_outlined));
+      await tester.pumpAndSettle();
+
+      // Form opens with pre-filled name
+      expect(find.byType(TextField), findsOneWidget);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  group('TagsScreen accessibility', () {
+    testWidgets('tag rows have semantic labels', (tester) async {
+      final tag = _makeTag(id: 'tag-1', name: 'Ragas');
+      final vm = FakeTagsViewModel(
+        initialState: TagsStateSuccess(tags: [tag]),
+      );
+
+      await tester.pumpWidget(_buildScreen(vm));
+
+      final semantics = tester.getSemantics(find.text('Ragas'));
+      expect(semantics.label, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue

Closes #76

## Summary

- Implemented `TagsViewModel` (`ChangeNotifier`) with sealed `TagsState` hierarchy (idle/loading/success/error) and per-operation error fields for create, update, delete
- Implemented `TagsScreen` — renders all states, FAB opens `TagFormSheet` for create, edit icon opens pre-filled form, delete icon shows confirmation dialog before calling `deleteTag`
- Implemented `CatppuccinColorPicker` — renders all 14 Mocha accent swatches as selectable circular chips with check mark indicator and semantic labels
- Implemented `TagFormSheet` — modal bottom sheet with name `TextFormField` and color picker, keyboard-aware padding, loading state on save

## Type of Change

feat

## Commit Convention

`feat(tags): implement TagsViewModel, TagsScreen, and Catppuccin color picker (#76)`

## Test Plan

- `test/unit/features/tags/viewmodels/tags_view_model_test.dart` — 15 unit tests covering all state transitions, CRUD operations, error fields, stream lifecycle
- `test/widget/features/tags/tags_screen_test.dart` — 12 widget tests covering state rendering, FAB, delete dialog, edit sheet, init call, accessibility

All 27 tests pass. `dart format` and `flutter analyze` — zero warnings on all new files.

## Checklist

- [x] All tests pass
- [x] `dart format` — no changes needed
- [x] `flutter analyze` — zero warnings
- [x] No CRITICAL or HIGH code review issues
- [x] PR linked to issue #76