### PR TITLE
feat(library): implement soft-delete from Library and Detail View (#91)

### DIFF
--- a/lib/features/library/screens/library_screen.dart
+++ b/lib/features/library/screens/library_screen.dart
@@ -1,0 +1,352 @@
+// LibraryScreen — main screen showing all active (non-deleted) notations.
+//
+// Route: /
+//
+// The screen observes [LibraryViewModel] via [ChangeNotifierProvider] and
+// renders one of four states: idle, loading, success (notation list), or
+// error.
+//
+// Delete interaction: each list item can be swiped from right-to-left to
+// reveal a delete background, which triggers a confirmation dialog. On
+// confirmation the notation is soft-deleted and a SnackBar with an "Undo"
+// action appears for 5 seconds. Tapping "Undo" calls
+// [LibraryViewModel.undoDelete].
+//
+// Dependencies are injected at the call site:
+//   ChangeNotifierProvider<LibraryViewModel>(
+//     create: (_) => LibraryViewModel(notationRepository, trashRepository),
+//     child: const LibraryScreen(),
+//   )
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/library/viewmodels/library_view_model.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Duration the "Undo" SnackBar is visible before the deletion is final.
+const Duration _kUndoDuration = Duration(seconds: 5);
+
+/// Vertical padding for the notation list.
+const EdgeInsets _kListPadding = EdgeInsets.symmetric(vertical: 4);
+
+/// Padding around the delete icon in the swipe background.
+const EdgeInsets _kSwipeIconPadding = EdgeInsets.symmetric(horizontal: 24);
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Main screen for browsing all active notations.
+///
+/// Reads [LibraryViewModel] from the widget tree via [ChangeNotifierProvider].
+/// Calls [LibraryViewModel.init] after the first frame.
+class LibraryScreen extends StatefulWidget {
+  /// Creates a [LibraryScreen].
+  const LibraryScreen({super.key});
+
+  @override
+  State<LibraryScreen> createState() => _LibraryScreenState();
+}
+
+class _LibraryScreenState extends State<LibraryScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<LibraryViewModel>().init();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<LibraryViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Library'),
+      ),
+      body: switch (vm.state) {
+        LibraryStateIdle() => const SizedBox.shrink(),
+        LibraryStateLoading() => const _LoadingView(),
+        LibraryStateSuccess(:final notations) => notations.isEmpty
+            ? const _EmptyView()
+            : _NotationListView(notations: notations),
+        LibraryStateError(:final message) => _ErrorView(message: message),
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private state views
+// ---------------------------------------------------------------------------
+
+/// Loading indicator while the notation stream is initialising.
+class _LoadingView extends StatelessWidget {
+  const _LoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+/// Empty state shown when there are no active notations.
+class _EmptyView extends StatelessWidget {
+  const _EmptyView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.music_note_outlined,
+            size: 64,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No notations yet',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Capture a new notation to get started.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Error view shown when the notation stream emits an error.
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load library',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Scrollable list of active notation rows.
+class _NotationListView extends StatelessWidget {
+  const _NotationListView({required this.notations});
+
+  final List<Notation> notations;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: _kListPadding,
+      itemCount: notations.length,
+      itemBuilder: (context, index) => _NotationRow(notation: notations[index]),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notation row
+// ---------------------------------------------------------------------------
+
+/// A single library row with swipe-to-delete and an undo SnackBar.
+class _NotationRow extends StatelessWidget {
+  const _NotationRow({required this.notation});
+
+  final Notation notation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: notation.title,
+      child: Dismissible(
+        key: ValueKey(notation.id),
+        direction: DismissDirection.endToStart,
+        background: const _SwipeDeleteBackground(),
+        confirmDismiss: (_) => _confirmDelete(context),
+        // Removal from list is driven by the stream; no local state needed.
+        onDismissed: (_) {},
+        child: _NotationRowContent(notation: notation),
+      ),
+    );
+  }
+
+  Future<bool?> _confirmDelete(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Move to Trash?'),
+        content: Text(
+          '"${notation.title}" will be moved to Trash. '
+          'You can restore it within 30 days.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(dialogContext).colorScheme.error,
+              foregroundColor: Theme.of(dialogContext).colorScheme.onError,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return false;
+    if (!context.mounted) return false;
+
+    final vm = context.read<LibraryViewModel>();
+    await vm.softDelete(notation.id);
+
+    if (!context.mounted) return true;
+
+    if (vm.operationError != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Could not delete notation. Please try again.'),
+        ),
+      );
+      vm.clearOperationError();
+      return false;
+    }
+
+    _showUndoSnackBar(context, vm);
+    return true;
+  }
+
+  void _showUndoSnackBar(BuildContext context, LibraryViewModel vm) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text('"${notation.title}" moved to Trash.'),
+          duration: _kUndoDuration,
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () => vm.undoDelete(notation.id),
+          ),
+        ),
+      );
+  }
+}
+
+/// Content of a single library row.
+class _NotationRowContent extends StatelessWidget {
+  const _NotationRowContent({required this.notation});
+
+  final Notation notation;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      minVerticalPadding: 12,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+      leading: Icon(
+        Icons.music_note_outlined,
+        color: Theme.of(context).colorScheme.primary,
+      ),
+      title: Text(
+        notation.title,
+        style: Theme.of(context).textTheme.bodyLarge,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: notation.artists.isNotEmpty
+          ? Text(
+              notation.artists.join(', '),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              overflow: TextOverflow.ellipsis,
+            )
+          : null,
+      trailing: Icon(
+        Icons.chevron_right,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+}
+
+/// Swipe-to-delete background shown when swiping a row from right-to-left.
+class _SwipeDeleteBackground extends StatelessWidget {
+  const _SwipeDeleteBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.errorContainer,
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: Padding(
+          padding: _kSwipeIconPadding,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Delete',
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onErrorContainer,
+                    ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.delete_outline,
+                color: Theme.of(context).colorScheme.onErrorContainer,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/library/viewmodels/library_view_model.dart
+++ b/lib/features/library/viewmodels/library_view_model.dart
@@ -1,0 +1,221 @@
+// LibraryViewModel — ChangeNotifier-based ViewModel for the Library screen.
+//
+// Subscribes to [NotationRepository.watchAllActive] and exposes state as a
+// sealed [LibraryState] hierarchy: idle / loading / success / error.
+//
+// Provides [softDelete] for moving a notation to trash from the Library,
+// and [undoDelete] for restoring it via [TrashRepository.restoreNotation]
+// within the undo window.
+//
+// A single [operationError] field surfaces per-operation failures without
+// replacing the main list state.
+//
+// Construction:
+//   LibraryViewModel(notationRepository, trashRepository)
+//
+// Lifecycle:
+//   Call [init] once (e.g. via addPostFrameCallback in initState).
+//   Disposal is handled by the ChangeNotifier lifecycle.
+
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// State hierarchy
+// ---------------------------------------------------------------------------
+
+/// Sealed state for [LibraryViewModel].
+///
+/// Variants: [LibraryStateIdle], [LibraryStateLoading],
+/// [LibraryStateSuccess], [LibraryStateError].
+sealed class LibraryState {
+  /// Creates a [LibraryState].
+  const LibraryState();
+}
+
+/// Initial state before [LibraryViewModel.init] is called.
+final class LibraryStateIdle extends LibraryState {
+  /// Creates a [LibraryStateIdle].
+  const LibraryStateIdle();
+}
+
+/// State while awaiting the first stream emission.
+final class LibraryStateLoading extends LibraryState {
+  /// Creates a [LibraryStateLoading].
+  const LibraryStateLoading();
+}
+
+/// State when the active notation list has been received from the stream.
+final class LibraryStateSuccess extends LibraryState {
+  /// Creates a [LibraryStateSuccess] with the given [notations].
+  ///
+  /// Parameters:
+  /// - [notations]: Current list of active (non-deleted) notations.
+  const LibraryStateSuccess({required this.notations});
+
+  /// Current list of active notations, ordered by [Notation.updatedAt]
+  /// descending.
+  final List<Notation> notations;
+}
+
+/// State when the stream emitted an error.
+final class LibraryStateError extends LibraryState {
+  /// Creates a [LibraryStateError] with the given [message].
+  ///
+  /// Parameters:
+  /// - [message]: Human-readable description of the error.
+  const LibraryStateError({required this.message});
+
+  /// Human-readable description of the stream error.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/// ViewModel for the Library screen.
+///
+/// Observes [NotationRepository.watchAllActive] and translates stream events
+/// into [LibraryState] values. Exposes [softDelete] and [undoDelete]
+/// operations that surface failures via [operationError] without interrupting
+/// the library list display.
+///
+/// State management contract:
+/// - [state] is the primary display state (idle / loading / success / error).
+/// - [operationError] is an auxiliary error field; it does not affect [state]
+///   so the list remains visible while an operation error is shown.
+class LibraryViewModel extends ChangeNotifier {
+  /// Creates a [LibraryViewModel] backed by the given repositories.
+  ///
+  /// Parameters:
+  /// - [_notationRepository]: Source of truth for active notation list.
+  /// - [_trashRepository]: Used to restore a soft-deleted notation on undo.
+  LibraryViewModel(this._notationRepository, this._trashRepository);
+
+  final NotationRepository _notationRepository;
+  final TrashRepository _trashRepository;
+  StreamSubscription<List<Notation>>? _subscription;
+
+  LibraryState _state = const LibraryStateIdle();
+  String? _operationError;
+
+  // -------------------------------------------------------------------------
+  // Public getters
+  // -------------------------------------------------------------------------
+
+  /// The current display state of the library screen.
+  LibraryState get state => _state;
+
+  /// Non-null when the most recent operation (softDelete / undoDelete) failed.
+  ///
+  /// Clear with [clearOperationError] after the error has been surfaced.
+  String? get operationError => _operationError;
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /// Subscribes to the active notation stream and begins emitting state
+  /// updates.
+  ///
+  /// Transitions immediately to [LibraryStateLoading], then to
+  /// [LibraryStateSuccess] or [LibraryStateError] as the stream emits.
+  /// Calling [init] again cancels the previous subscription before
+  /// restarting.
+  void init() {
+    _subscription?.cancel();
+    _state = const LibraryStateLoading();
+    notifyListeners();
+
+    _subscription = _notationRepository.watchAllActive().listen(
+      (notations) {
+        _state = LibraryStateSuccess(notations: notations);
+        notifyListeners();
+      },
+      onError: (Object error, StackTrace stack) {
+        log(
+          'LibraryViewModel: stream error — $error',
+          name: 'LibraryViewModel',
+          error: error,
+          stackTrace: stack,
+        );
+        _state = LibraryStateError(message: error.toString());
+        notifyListeners();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  // -------------------------------------------------------------------------
+  // Operations
+  // -------------------------------------------------------------------------
+
+  /// Soft-deletes the notation identified by [id].
+  ///
+  /// Sets `deleted_at` on the notation row, removing it from the active list.
+  /// On failure [operationError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to soft-delete.
+  Future<void> softDelete(String id) async {
+    try {
+      await _notationRepository.softDelete(id);
+      log('LibraryViewModel: soft-deleted notation $id',
+          name: 'LibraryViewModel');
+    } on Exception catch (e, st) {
+      log(
+        'LibraryViewModel: softDelete failed — $e',
+        name: 'LibraryViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _operationError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// Restores the notation identified by [id] from the trash.
+  ///
+  /// Called when the user taps "Undo" on the deletion SnackBar. On failure
+  /// [operationError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to restore.
+  Future<void> undoDelete(String id) async {
+    try {
+      await _trashRepository.restoreNotation(id);
+      log('LibraryViewModel: restored notation $id', name: 'LibraryViewModel');
+    } on Exception catch (e, st) {
+      log(
+        'LibraryViewModel: undoDelete failed — $e',
+        name: 'LibraryViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _operationError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Error reset
+  // -------------------------------------------------------------------------
+
+  /// Clears [operationError] and notifies listeners.
+  void clearOperationError() {
+    _operationError = null;
+    notifyListeners();
+  }
+}

--- a/lib/features/notation_detail/screens/notation_detail_screen.dart
+++ b/lib/features/notation_detail/screens/notation_detail_screen.dart
@@ -1,0 +1,410 @@
+// NotationDetailScreen — screen showing full details for a single notation.
+//
+// Route: /notation/:id
+//
+// The screen observes [NotationDetailViewModel] via [ChangeNotifierProvider]
+// and renders one of five states: idle, loading, success, notFound, error.
+//
+// Delete interaction: the AppBar "Delete" action opens a confirmation dialog.
+// On confirmation the notation is soft-deleted, a SnackBar with an "Undo"
+// action appears for 5 seconds, and the screen navigates back to the library
+// (route '/').
+//
+// Dependencies are injected at the call site:
+//   ChangeNotifierProvider<NotationDetailViewModel>(
+//     create: (_) => NotationDetailViewModel(
+//       notationRepository,
+//       trashRepository,
+//     ),
+//     child: NotationDetailScreen(notationId: id),
+//   )
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/notation_detail/viewmodels/notation_detail_view_model.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Duration the "Undo" SnackBar is visible before the deletion is final.
+const Duration _kUndoDuration = Duration(seconds: 5);
+
+/// Horizontal padding for detail content sections.
+const EdgeInsets _kContentPadding =
+    EdgeInsets.symmetric(horizontal: 16, vertical: 8);
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Detail screen for a single notation.
+///
+/// Reads [NotationDetailViewModel] from the widget tree. Calls
+/// [NotationDetailViewModel.loadNotation] after the first frame.
+class NotationDetailScreen extends StatefulWidget {
+  /// Creates a [NotationDetailScreen] for the notation with [notationId].
+  ///
+  /// Parameters:
+  /// - [notationId]: UUIDv4 of the notation to display.
+  const NotationDetailScreen({required this.notationId, super.key});
+
+  /// UUIDv4 of the notation to display.
+  final String notationId;
+
+  @override
+  State<NotationDetailScreen> createState() => _NotationDetailScreenState();
+}
+
+class _NotationDetailScreenState extends State<NotationDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<NotationDetailViewModel>().loadNotation(widget.notationId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<NotationDetailViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: _AppBarTitle(state: vm.state),
+        actions: [
+          if (vm.state is NotationDetailStateSuccess)
+            Semantics(
+              label: 'Delete notation',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Delete',
+                onPressed: () => _confirmDelete(context, vm, widget.notationId),
+              ),
+            ),
+        ],
+      ),
+      body: switch (vm.state) {
+        NotationDetailStateIdle() => const SizedBox.shrink(),
+        NotationDetailStateLoading() => const _LoadingView(),
+        NotationDetailStateSuccess(:final detail) =>
+          _DetailContent(detail: detail),
+        NotationDetailStateNotFound() => const _NotFoundView(),
+        NotationDetailStateError(:final message) =>
+          _ErrorView(message: message),
+      },
+    );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    NotationDetailViewModel vm,
+    String id,
+  ) async {
+    final title = vm.state is NotationDetailStateSuccess
+        ? (vm.state as NotationDetailStateSuccess).detail.notation.title
+        : 'this notation';
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Move to Trash?'),
+        content: Text(
+          '"$title" will be moved to Trash. '
+          'You can restore it within 30 days.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(dialogContext).colorScheme.error,
+              foregroundColor: Theme.of(dialogContext).colorScheme.onError,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+    if (!context.mounted) return;
+
+    // Navigate back and show the undo SnackBar from the library context.
+    // The onDeleted callback fires after softDelete succeeds.
+    await vm.softDelete(
+      id,
+      onDeleted: () {
+        if (!context.mounted) return;
+        Navigator.of(context).popUntil((route) => route.isFirst);
+        _showUndoSnackBar(context, vm, id, title);
+      },
+    );
+
+    if (!context.mounted) return;
+
+    if (vm.operationError != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not delete notation. Please try again.'),
+        ),
+      );
+      vm.clearOperationError();
+    }
+  }
+
+  void _showUndoSnackBar(
+    BuildContext context,
+    NotationDetailViewModel vm,
+    String id,
+    String title,
+  ) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text('"$title" moved to Trash.'),
+          duration: _kUndoDuration,
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () => vm.undoDelete(id),
+          ),
+        ),
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AppBar title
+// ---------------------------------------------------------------------------
+
+/// Adaptive title widget for the detail AppBar.
+///
+/// Shows the notation title once loaded, or a placeholder otherwise.
+class _AppBarTitle extends StatelessWidget {
+  const _AppBarTitle({required this.state});
+
+  final NotationDetailState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      NotationDetailStateSuccess(:final detail) =>
+        Text(detail.notation.title, overflow: TextOverflow.ellipsis),
+      _ => const Text('Notation'),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private state views
+// ---------------------------------------------------------------------------
+
+/// Loading indicator while the notation is being fetched.
+class _LoadingView extends StatelessWidget {
+  const _LoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+/// Shown when the notation id does not exist in the repository.
+class _NotFoundView extends StatelessWidget {
+  const _NotFoundView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.search_off_outlined,
+              size: 48,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Notation not found',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shown when loading fails with an exception.
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load notation',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detail content
+// ---------------------------------------------------------------------------
+
+/// Main content for a successfully loaded notation.
+class _DetailContent extends StatelessWidget {
+  const _DetailContent({required this.detail});
+
+  final NotationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final n = detail.notation;
+    return SingleChildScrollView(
+      padding: _kContentPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionTitle(title: n.title),
+          const SizedBox(height: 8),
+          if (n.artists.isNotEmpty) ...[
+            _MetadataRow(
+              icon: Icons.person_outline,
+              label: n.artists.join(', '),
+            ),
+            const SizedBox(height: 4),
+          ],
+          if (n.languages.isNotEmpty) ...[
+            _MetadataRow(
+              icon: Icons.language_outlined,
+              label: n.languages.join(', '),
+            ),
+            const SizedBox(height: 4),
+          ],
+          if (n.timeSig != null) ...[
+            _MetadataRow(
+              icon: Icons.access_time_outlined,
+              label: n.timeSig!,
+            ),
+            const SizedBox(height: 4),
+          ],
+          if (n.keySig != null) ...[
+            _MetadataRow(
+              icon: Icons.music_note_outlined,
+              label: n.keySig!,
+            ),
+            const SizedBox(height: 4),
+          ],
+          if (n.notes.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Notes',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              n.notes,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+          const SizedBox(height: 16),
+          if (detail.pages.isNotEmpty) ...[
+            Text(
+              'Pages (${detail.pages.length})',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Large title for the notation.
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.headlineMedium,
+    );
+  }
+}
+
+/// A row showing an icon and a metadata label.
+class _MetadataRow extends StatelessWidget {
+  const _MetadataRow({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/notation_detail/viewmodels/notation_detail_view_model.dart
+++ b/lib/features/notation_detail/viewmodels/notation_detail_view_model.dart
@@ -1,0 +1,232 @@
+// NotationDetailViewModel — ChangeNotifier-based ViewModel for the notation
+// detail screen.
+//
+// Loads a fully-hydrated [NotationDetail] via [NotationRepository.loadNotation]
+// and exposes state as a sealed [NotationDetailState] hierarchy:
+// idle / loading / success / notFound / error.
+//
+// Provides [softDelete] for moving the notation to trash from the detail view.
+// The [onDeleted] callback allows the caller (screen) to trigger navigation
+// back to the library after a successful delete.
+//
+// Provides [undoDelete] for restoring the notation via
+// [TrashRepository.restoreNotation] within the undo window.
+//
+// A single [operationError] field surfaces per-operation failures without
+// replacing the main state.
+//
+// Construction:
+//   NotationDetailViewModel(notationRepository, trashRepository)
+//
+// Lifecycle:
+//   Call [loadNotation] once per navigation to the detail screen.
+//   Disposal is handled by the ChangeNotifier lifecycle.
+
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// State hierarchy
+// ---------------------------------------------------------------------------
+
+/// Sealed state for [NotationDetailViewModel].
+///
+/// Variants: [NotationDetailStateIdle], [NotationDetailStateLoading],
+/// [NotationDetailStateSuccess], [NotationDetailStateNotFound],
+/// [NotationDetailStateError].
+sealed class NotationDetailState {
+  /// Creates a [NotationDetailState].
+  const NotationDetailState();
+}
+
+/// Initial state before [NotationDetailViewModel.loadNotation] is called.
+final class NotationDetailStateIdle extends NotationDetailState {
+  /// Creates a [NotationDetailStateIdle].
+  const NotationDetailStateIdle();
+}
+
+/// State while [NotationDetailViewModel.loadNotation] is in progress.
+final class NotationDetailStateLoading extends NotationDetailState {
+  /// Creates a [NotationDetailStateLoading].
+  const NotationDetailStateLoading();
+}
+
+/// State when the notation was successfully loaded.
+final class NotationDetailStateSuccess extends NotationDetailState {
+  /// Creates a [NotationDetailStateSuccess] with the given [detail].
+  ///
+  /// Parameters:
+  /// - [detail]: Fully-hydrated notation aggregate.
+  const NotationDetailStateSuccess({required this.detail});
+
+  /// Fully-hydrated notation aggregate for display.
+  final NotationDetail detail;
+}
+
+/// State when no notation with the requested id exists.
+final class NotationDetailStateNotFound extends NotationDetailState {
+  /// Creates a [NotationDetailStateNotFound].
+  const NotationDetailStateNotFound();
+}
+
+/// State when loading the notation failed with an exception.
+final class NotationDetailStateError extends NotationDetailState {
+  /// Creates a [NotationDetailStateError] with the given [message].
+  ///
+  /// Parameters:
+  /// - [message]: Human-readable description of the error.
+  const NotationDetailStateError({required this.message});
+
+  /// Human-readable description of the load error.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/// ViewModel for the notation detail screen.
+///
+/// Loads a single [NotationDetail] and translates the result into a
+/// [NotationDetailState] value. Exposes [softDelete] and [undoDelete]
+/// operations that surface failures via [operationError] without interrupting
+/// the detail view display.
+///
+/// State management contract:
+/// - [state] is the primary display state.
+/// - [operationError] is an auxiliary error field set on operation failure.
+class NotationDetailViewModel extends ChangeNotifier {
+  /// Creates a [NotationDetailViewModel] backed by the given repositories.
+  ///
+  /// Parameters:
+  /// - [_notationRepository]: Source of truth for notation loading and delete.
+  /// - [_trashRepository]: Used to restore a soft-deleted notation on undo.
+  NotationDetailViewModel(this._notationRepository, this._trashRepository);
+
+  final NotationRepository _notationRepository;
+  final TrashRepository _trashRepository;
+
+  NotationDetailState _state = const NotationDetailStateIdle();
+  String? _operationError;
+
+  // -------------------------------------------------------------------------
+  // Public getters
+  // -------------------------------------------------------------------------
+
+  /// The current display state of the notation detail screen.
+  NotationDetailState get state => _state;
+
+  /// Non-null when the most recent operation (softDelete / undoDelete) failed.
+  ///
+  /// Clear with [clearOperationError] after the error has been surfaced.
+  String? get operationError => _operationError;
+
+  // -------------------------------------------------------------------------
+  // Load
+  // -------------------------------------------------------------------------
+
+  /// Loads the notation identified by [id] and transitions state accordingly.
+  ///
+  /// Transitions to [NotationDetailStateLoading] while in flight, then to
+  /// [NotationDetailStateSuccess], [NotationDetailStateNotFound] (when the
+  /// repository returns null), or [NotationDetailStateError] on exception.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to load.
+  Future<void> loadNotation(String id) async {
+    _state = const NotationDetailStateLoading();
+    notifyListeners();
+
+    try {
+      final detail = await _notationRepository.loadNotation(id);
+      if (detail == null) {
+        _state = const NotationDetailStateNotFound();
+      } else {
+        _state = NotationDetailStateSuccess(detail: detail);
+      }
+    } on Exception catch (e, st) {
+      log(
+        'NotationDetailViewModel: loadNotation failed — $e',
+        name: 'NotationDetailViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _state = NotationDetailStateError(message: e.toString());
+    }
+    notifyListeners();
+  }
+
+  // -------------------------------------------------------------------------
+  // Operations
+  // -------------------------------------------------------------------------
+
+  /// Soft-deletes the notation identified by [id].
+  ///
+  /// Sets `deleted_at` on the notation row, moving it to trash. On success
+  /// the optional [onDeleted] callback is invoked so the caller can navigate
+  /// back to the library. On failure [operationError] is populated.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to soft-delete.
+  /// - [onDeleted]: Optional callback invoked after a successful delete.
+  Future<void> softDelete(String id, {VoidCallback? onDeleted}) async {
+    try {
+      await _notationRepository.softDelete(id);
+      log(
+        'NotationDetailViewModel: soft-deleted notation $id',
+        name: 'NotationDetailViewModel',
+      );
+      onDeleted?.call();
+    } on Exception catch (e, st) {
+      log(
+        'NotationDetailViewModel: softDelete failed — $e',
+        name: 'NotationDetailViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _operationError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// Restores the notation identified by [id] from the trash.
+  ///
+  /// Called when the user taps "Undo" on the deletion SnackBar. On failure
+  /// [operationError] is populated and [notifyListeners] is called.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to restore.
+  Future<void> undoDelete(String id) async {
+    try {
+      await _trashRepository.restoreNotation(id);
+      log(
+        'NotationDetailViewModel: restored notation $id',
+        name: 'NotationDetailViewModel',
+      );
+    } on Exception catch (e, st) {
+      log(
+        'NotationDetailViewModel: undoDelete failed — $e',
+        name: 'NotationDetailViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _operationError = e.toString();
+      notifyListeners();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Error reset
+  // -------------------------------------------------------------------------
+
+  /// Clears [operationError] and notifies listeners.
+  void clearOperationError() {
+    _operationError = null;
+    notifyListeners();
+  }
+}

--- a/test/unit/features/library/viewmodels/library_view_model_test.dart
+++ b/test/unit/features/library/viewmodels/library_view_model_test.dart
@@ -1,0 +1,261 @@
+// Unit tests for LibraryViewModel.
+//
+// Covers all public state transitions and soft-delete lifecycle:
+//   init            → idle / loading / success / error
+//   softDelete      → success path and error path
+//   undoDelete      → calls TrashRepository.restoreNotation
+//
+// Uses FakeNotationRepository and FakeTrashRepository to control stream and
+// error scenarios without touching the database.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/library/viewmodels/library_view_model.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  final _controller = StreamController<List<Notation>>.broadcast();
+  Object? _softDeleteError;
+
+  final List<String> softDeletedIds = [];
+
+  void emitNotations(List<Notation> notations) => _controller.add(notations);
+
+  void emitWatchError(Object error) => _controller.addError(error);
+
+  void setSoftDeleteError(Object? e) => _softDeleteError = e;
+
+  @override
+  Stream<List<Notation>> watchAllActive() => _controller.stream;
+
+  @override
+  Future<void> softDelete(String id) async {
+    if (_softDeleteError != null) throw _softDeleteError!;
+    softDeletedIds.add(id);
+  }
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  void close() => _controller.close();
+}
+
+class FakeTrashRepository implements TrashRepository {
+  final List<String> restoredIds = [];
+  Object? _restoreError;
+
+  void setRestoreError(Object? e) => _restoreError = e;
+
+  @override
+  Future<void> restoreNotation(String id) async {
+    if (_restoreError != null) throw _restoreError!;
+    restoredIds.add(id);
+  }
+
+  @override
+  Stream<List<Notation>> watchTrashedNotations() => const Stream.empty();
+
+  @override
+  Future<void> purgeNotation(String id) async {}
+
+  @override
+  Future<void> purgeAll() async {}
+
+  @override
+  Future<int> autoPurgeExpired() async => 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Notation _makeNotation(String id) => Notation(
+      id: id,
+      title: 'Test $id',
+      artists: const [],
+      languages: const [],
+      notes: '',
+      playCount: 0,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository notationRepo;
+  late FakeTrashRepository trashRepo;
+  late LibraryViewModel vm;
+
+  setUp(() {
+    notationRepo = FakeNotationRepository();
+    trashRepo = FakeTrashRepository();
+    vm = LibraryViewModel(notationRepo, trashRepo);
+  });
+
+  tearDown(() {
+    vm.dispose();
+    notationRepo.close();
+  });
+
+  group('initial state', () {
+    test('starts in idle state', () {
+      expect(vm.state, isA<LibraryStateIdle>());
+    });
+  });
+
+  group('init', () {
+    test('transitions to loading immediately', () {
+      vm.init();
+      expect(vm.state, isA<LibraryStateLoading>());
+    });
+
+    test('transitions to success when stream emits notations', () async {
+      final notations = [_makeNotation('1'), _makeNotation('2')];
+      vm.init();
+
+      notationRepo.emitNotations(notations);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.state, isA<LibraryStateSuccess>());
+      final success = vm.state as LibraryStateSuccess;
+      expect(success.notations, hasLength(2));
+      expect(success.notations.first.id, '1');
+    });
+
+    test('transitions to success with empty list', () async {
+      vm.init();
+      notationRepo.emitNotations([]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.state, isA<LibraryStateSuccess>());
+      expect((vm.state as LibraryStateSuccess).notations, isEmpty);
+    });
+
+    test('transitions to error when stream emits error', () async {
+      vm.init();
+      notationRepo.emitWatchError(Exception('db failure'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.state, isA<LibraryStateError>());
+      final error = vm.state as LibraryStateError;
+      expect(error.message, contains('db failure'));
+    });
+
+    test('notifies listeners on each emission', () async {
+      var callCount = 0;
+      vm.addListener(() => callCount++);
+
+      vm.init();
+      expect(callCount, 1); // loading
+
+      notationRepo.emitNotations([_makeNotation('1')]);
+      await Future<void>.delayed(Duration.zero);
+      expect(callCount, 2); // success
+
+      notationRepo.emitNotations([_makeNotation('2')]);
+      await Future<void>.delayed(Duration.zero);
+      expect(callCount, 3); // updated success
+    });
+
+    test('re-calling init cancels previous subscription', () async {
+      vm.init();
+      notationRepo.emitNotations([_makeNotation('1')]);
+      await Future<void>.delayed(Duration.zero);
+
+      vm.init(); // re-init should reset to loading
+      expect(vm.state, isA<LibraryStateLoading>());
+    });
+  });
+
+  group('softDelete', () {
+    setUp(() async {
+      vm.init();
+      notationRepo.emitNotations([_makeNotation('a'), _makeNotation('b')]);
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('calls NotationRepository.softDelete with correct id', () async {
+      await vm.softDelete('a');
+      expect(notationRepo.softDeletedIds, contains('a'));
+    });
+
+    test('clears operationError on success', () async {
+      await vm.softDelete('a');
+      expect(vm.operationError, isNull);
+    });
+
+    test('sets operationError on failure', () async {
+      notationRepo.setSoftDeleteError(Exception('delete error'));
+      await vm.softDelete('a');
+      expect(vm.operationError, isNotNull);
+      expect(vm.operationError, contains('delete error'));
+    });
+
+    test('notifies listeners on error', () async {
+      var callCount = 0;
+      vm.addListener(() => callCount++);
+      notationRepo.setSoftDeleteError(Exception('err'));
+      await vm.softDelete('a');
+      expect(callCount, greaterThan(0));
+    });
+  });
+
+  group('undoDelete', () {
+    test('calls TrashRepository.restoreNotation with correct id', () async {
+      await vm.undoDelete('a');
+      expect(trashRepo.restoredIds, contains('a'));
+    });
+
+    test('sets operationError when restore fails', () async {
+      trashRepo.setRestoreError(Exception('restore failed'));
+      await vm.undoDelete('a');
+      expect(vm.operationError, isNotNull);
+      expect(vm.operationError, contains('restore failed'));
+    });
+  });
+
+  group('clearOperationError', () {
+    test('clears operationError and notifies listeners', () async {
+      notationRepo.setSoftDeleteError(Exception('err'));
+      await vm.softDelete('a');
+      expect(vm.operationError, isNotNull);
+
+      var callCount = 0;
+      vm.addListener(() => callCount++);
+      vm.clearOperationError();
+
+      expect(vm.operationError, isNull);
+      expect(callCount, 1);
+    });
+  });
+}

--- a/test/unit/features/notation_detail/viewmodels/notation_detail_view_model_test.dart
+++ b/test/unit/features/notation_detail/viewmodels/notation_detail_view_model_test.dart
@@ -1,0 +1,239 @@
+// Unit tests for NotationDetailViewModel.
+//
+// Covers all public state transitions and operations:
+//   loadNotation    → loading / success / error / not-found
+//   softDelete      → success path, error path, navigation callback
+//   undoDelete      → calls TrashRepository.restoreNotation
+//
+// Uses FakeNotationRepository and FakeTrashRepository without touching
+// the database.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/notation_detail/viewmodels/notation_detail_view_model.dart';
+import 'package:swaralipi/shared/models/custom_field_value.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  NotationDetail? _detail;
+  Object? _loadError;
+  Object? _softDeleteError;
+
+  final List<String> softDeletedIds = [];
+
+  void setDetail(NotationDetail? d) => _detail = d;
+  void setLoadError(Object? e) => _loadError = e;
+  void setSoftDeleteError(Object? e) => _softDeleteError = e;
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async {
+    if (_loadError != null) throw _loadError!;
+    return _detail;
+  }
+
+  @override
+  Future<void> softDelete(String id) async {
+    if (_softDeleteError != null) throw _softDeleteError!;
+    softDeletedIds.add(id);
+  }
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+}
+
+class FakeTrashRepository implements TrashRepository {
+  final List<String> restoredIds = [];
+  Object? _restoreError;
+
+  void setRestoreError(Object? e) => _restoreError = e;
+
+  @override
+  Future<void> restoreNotation(String id) async {
+    if (_restoreError != null) throw _restoreError!;
+    restoredIds.add(id);
+  }
+
+  @override
+  Stream<List<Notation>> watchTrashedNotations() => const Stream.empty();
+
+  @override
+  Future<void> purgeNotation(String id) async {}
+
+  @override
+  Future<void> purgeAll() async {}
+
+  @override
+  Future<int> autoPurgeExpired() async => 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Notation _makeNotation(String id) => Notation(
+      id: id,
+      title: 'Test $id',
+      artists: const [],
+      languages: const [],
+      notes: '',
+      playCount: 0,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    );
+
+NotationDetail _makeDetail(String id) => NotationDetail(
+      notation: _makeNotation(id),
+      pages: const <NotationPage>[],
+      tags: const <Tag>[],
+      customFieldValues: const <CustomFieldValue>[],
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository notationRepo;
+  late FakeTrashRepository trashRepo;
+  late NotationDetailViewModel vm;
+
+  setUp(() {
+    notationRepo = FakeNotationRepository();
+    trashRepo = FakeTrashRepository();
+    vm = NotationDetailViewModel(notationRepo, trashRepo);
+  });
+
+  tearDown(() => vm.dispose());
+
+  group('initial state', () {
+    test('starts in idle state', () {
+      expect(vm.state, isA<NotationDetailStateIdle>());
+    });
+  });
+
+  group('loadNotation', () {
+    test('transitions to loading then success when notation is found',
+        () async {
+      final detail = _makeDetail('x');
+      notationRepo.setDetail(detail);
+
+      final states = <NotationDetailState>[];
+      vm.addListener(() => states.add(vm.state));
+
+      await vm.loadNotation('x');
+
+      expect(states.first, isA<NotationDetailStateLoading>());
+      expect(states.last, isA<NotationDetailStateSuccess>());
+      final success = states.last as NotationDetailStateSuccess;
+      expect(success.detail.notation.id, 'x');
+    });
+
+    test('transitions to notFound when notation is null', () async {
+      notationRepo.setDetail(null);
+      await vm.loadNotation('missing');
+      expect(vm.state, isA<NotationDetailStateNotFound>());
+    });
+
+    test('transitions to error when repository throws', () async {
+      notationRepo.setLoadError(Exception('load error'));
+      await vm.loadNotation('x');
+      expect(vm.state, isA<NotationDetailStateError>());
+      final error = vm.state as NotationDetailStateError;
+      expect(error.message, contains('load error'));
+    });
+  });
+
+  group('softDelete', () {
+    setUp(() async {
+      notationRepo.setDetail(_makeDetail('n1'));
+      await vm.loadNotation('n1');
+    });
+
+    test('calls NotationRepository.softDelete with correct id', () async {
+      await vm.softDelete('n1');
+      expect(notationRepo.softDeletedIds, contains('n1'));
+    });
+
+    test('clears operationError on success', () async {
+      await vm.softDelete('n1');
+      expect(vm.operationError, isNull);
+    });
+
+    test('sets operationError on failure', () async {
+      notationRepo.setSoftDeleteError(Exception('delete failed'));
+      await vm.softDelete('n1');
+      expect(vm.operationError, isNotNull);
+      expect(vm.operationError, contains('delete failed'));
+    });
+
+    test('invokes onDeleted callback on success', () async {
+      var callbackInvoked = false;
+      await vm.softDelete('n1', onDeleted: () => callbackInvoked = true);
+      expect(callbackInvoked, isTrue);
+    });
+
+    test('does not invoke onDeleted callback on failure', () async {
+      notationRepo.setSoftDeleteError(Exception('err'));
+      var callbackInvoked = false;
+      await vm.softDelete('n1', onDeleted: () => callbackInvoked = true);
+      expect(callbackInvoked, isFalse);
+    });
+  });
+
+  group('undoDelete', () {
+    test('calls TrashRepository.restoreNotation with correct id', () async {
+      await vm.undoDelete('n1');
+      expect(trashRepo.restoredIds, contains('n1'));
+    });
+
+    test('sets operationError when restore fails', () async {
+      trashRepo.setRestoreError(Exception('restore failed'));
+      await vm.undoDelete('n1');
+      expect(vm.operationError, isNotNull);
+      expect(vm.operationError, contains('restore failed'));
+    });
+  });
+
+  group('clearOperationError', () {
+    test('clears operationError and notifies', () async {
+      notationRepo.setSoftDeleteError(Exception('err'));
+      await vm.softDelete('n1');
+      expect(vm.operationError, isNotNull);
+
+      var called = false;
+      vm.addListener(() => called = true);
+      vm.clearOperationError();
+
+      expect(vm.operationError, isNull);
+      expect(called, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Closes #91

## Summary
- Add `LibraryViewModel` with `softDelete(id)` and `undoDelete(id)`, backed by `NotationRepository.watchAllActive` stream
- Add `NotationDetailViewModel` with `loadNotation`, `softDelete(id, onDeleted)`, and `undoDelete(id)` one-shot load
- Add `LibraryScreen` with swipe-to-delete (`Dismissible`, right-to-left), confirmation dialog, and 5-second undo `SnackBar`
- Add `NotationDetailScreen` showing notation metadata with an AppBar delete icon; navigates back to `/` after delete and shows undo `SnackBar`

## Type of Change
- [x] feat — new capability

## Commit Convention
`feat(library): implement soft-delete from Library and Detail View (#91)`

## Test Plan
- [x] Unit tests written: `LibraryViewModel` (14 tests) and `NotationDetailViewModel` (12 tests)
- [x] `flutter test test/unit` passes — 832 tests, 0 failures
- [x] Coverage ≥ 80% on all new ViewModel files
- [x] `flutter analyze` — zero warnings on new files
- [x] `dart format` applied

## Screenshots / Recordings
UI-only screens — no device testing required for this task (ViewModel + Screen scaffolding).

## Checklist
- [x] No `print` statements (uses `dart:developer` `log`)
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)` — all `on Exception catch`
- [x] Generated files committed (`.g.dart`)
- [x] No hardcoded secrets