### PR TITLE
feat(edit): implement edit notation flow — re-enter metadata form and page editor (#89)

### DIFF
--- a/lib/features/capture/data/notation_repository_impl.dart
+++ b/lib/features/capture/data/notation_repository_impl.dart
@@ -197,6 +197,23 @@ final class NotationRepositoryImpl implements NotationRepository {
     );
   }
 
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {
+    await _pageDao.updatePage(
+      NotationPagesTableCompanion(
+        id: Value(pageId),
+        renderParams: Value(renderParamsJson),
+      ),
+    );
+    log(
+      'NotationRepositoryImpl: updated renderParams for page $pageId',
+      name: 'NotationRepository',
+    );
+  }
+
   // -------------------------------------------------------------------------
   // Private write helpers
   // -------------------------------------------------------------------------

--- a/lib/features/edit/screens/edit_metadata_form_screen.dart
+++ b/lib/features/edit/screens/edit_metadata_form_screen.dart
@@ -1,0 +1,1074 @@
+// edit_metadata_form_screen.dart — Metadata form screen for the edit flow.
+//
+// Reuses the MetadataFormViewModel for loading picker dependencies (tags,
+// instruments, custom fields) but delegates the save operation to
+// EditNotationViewModel so that the edit path calls
+// NotationRepository.updateNotation instead of saveNotation.
+//
+// The form is pre-populated by reading EditNotationViewModel.formState on
+// first frame and pushing those values into the MetadataFormViewModel and
+// the associated TextEditingControllers.
+//
+// On successful save (EditNotationSaveDone), the screen navigates back by
+// popping until the route at depth 0 (NotationDetailScreen) is reached.
+//
+// Dependencies are provided above this widget via ChangeNotifierProvider:
+//   - EditNotationViewModel (for current form state + save)
+//   - CaptureSessionViewModel (for updated pages from the page editor)
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/capture/viewmodels/capture_session_view_model.dart';
+import 'package:swaralipi/features/capture/viewmodels/metadata_form_view_model.dart';
+import 'package:swaralipi/features/edit/viewmodels/edit_notation_view_model.dart';
+import 'package:swaralipi/shared/models/custom_field_definition.dart';
+import 'package:swaralipi/shared/models/instrument_instance.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/render_params.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Horizontal padding for the form body.
+const EdgeInsets _kFormPadding =
+    EdgeInsets.symmetric(horizontal: 16, vertical: 12);
+
+/// Vertical gap between form sections.
+const double _kSectionGap = 20.0;
+
+/// Vertical gap between a section label and its content.
+const double _kLabelGap = 8.0;
+
+/// Vertical gap between two chips in a row.
+const double _kChipSpacing = 8.0;
+
+/// Maximum width of the form content, centered on wide screens.
+const double _kMaxFormWidth = 640.0;
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Metadata form screen for the edit-notation flow.
+///
+/// Pre-populates the form from [EditNotationViewModel.formState] and saves
+/// via [EditNotationViewModel.save] using pages from [CaptureSessionViewModel].
+///
+/// Reads [EditNotationViewModel] and [CaptureSessionViewModel] from the
+/// widget tree. Also creates an internal [MetadataFormViewModel] solely for
+/// loading picker dependencies (tags, instruments, custom field definitions).
+class EditMetadataFormScreen extends StatefulWidget {
+  /// Creates an [EditMetadataFormScreen].
+  ///
+  /// Parameters:
+  /// - [notationId]: UUIDv4 of the notation being edited.
+  /// - [tagRepository]: Source of truth for tags.
+  /// - [instrumentRepository]: Source of truth for instruments.
+  /// - [customFieldRepository]: Source of truth for custom field definitions.
+  const EditMetadataFormScreen({
+    required this.notationId,
+    required this.tagRepository,
+    required this.instrumentRepository,
+    required this.customFieldRepository,
+    super.key,
+  });
+
+  /// UUIDv4 of the notation being edited.
+  final String notationId;
+
+  /// Source of truth for tags.
+  final TagRepository tagRepository;
+
+  /// Source of truth for instruments.
+  final InstrumentRepository instrumentRepository;
+
+  /// Source of truth for custom field definitions.
+  final CustomFieldRepository customFieldRepository;
+
+  @override
+  State<EditMetadataFormScreen> createState() =>
+      _EditMetadataFormScreenState();
+}
+
+class _EditMetadataFormScreenState extends State<EditMetadataFormScreen> {
+  late final MetadataFormViewModel _depsVm;
+  late final TextEditingController _titleController;
+  late final TextEditingController _timeSigController;
+  late final TextEditingController _keySigController;
+  late final TextEditingController _notesController;
+  late final TextEditingController _artistInputController;
+
+  bool _prePopulated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _depsVm = MetadataFormViewModel(
+      tagRepository: widget.tagRepository,
+      instrumentRepository: widget.instrumentRepository,
+      customFieldRepository: widget.customFieldRepository,
+      // NotationRepository and FileStorageService not used in edit deps mode.
+      notationRepository: _NoopNotationRepository(),
+      fileStorageService: _NoopFileStorageService(),
+      drafts: const [],
+    );
+
+    _titleController = TextEditingController();
+    _timeSigController = TextEditingController();
+    _keySigController = TextEditingController();
+    _notesController = TextEditingController();
+    _artistInputController = TextEditingController();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _depsVm.loadDependencies();
+      _prePopulateControllers();
+    });
+  }
+
+  void _prePopulateControllers() {
+    final editVm = context.read<EditNotationViewModel>();
+    final fs = editVm.formState;
+
+    // Sync text controllers with pre-populated form state.
+    _titleController.text = fs.title;
+    _timeSigController.text = fs.timeSig ?? '';
+    _keySigController.text = fs.keySig ?? '';
+    _notesController.text = fs.notes;
+
+    // Keep EditNotationViewModel in sync with initial controller values.
+    editVm
+      ..setTitle(fs.title)
+      ..setTimeSig(fs.timeSig ?? '')
+      ..setKeySig(fs.keySig ?? '')
+      ..setNotes(fs.notes);
+
+    setState(() => _prePopulated = true);
+  }
+
+  @override
+  void dispose() {
+    _depsVm.dispose();
+    _titleController.dispose();
+    _timeSigController.dispose();
+    _keySigController.dispose();
+    _notesController.dispose();
+    _artistInputController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final editVm = context.watch<EditNotationViewModel>();
+
+    // React to save state changes.
+    _handleSaveState(editVm.saveState);
+
+    return ChangeNotifierProvider<MetadataFormViewModel>.value(
+      value: _depsVm,
+      child: Builder(
+        builder: (innerContext) {
+          final depsVm = innerContext.watch<MetadataFormViewModel>();
+
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Edit Notation'),
+              actions: [
+                _EditSaveButton(
+                  enabled: editVm.isTitleValid,
+                  isSaving: editVm.saveState is EditNotationSaving,
+                ),
+                const SizedBox(width: 8),
+              ],
+            ),
+            body: switch (depsVm.depsState) {
+              MetadataFormDepsIdle() ||
+              MetadataFormDepsLoading() =>
+                const _LoadingView(),
+              MetadataFormDepsError(:final message) =>
+                _ErrorView(message: message),
+              MetadataFormDepsSuccess(
+                :final tags,
+                :final instruments,
+                :final customFieldDefinitions,
+              ) =>
+                _prePopulated
+                    ? _EditFormBody(
+                        tags: tags,
+                        instruments: instruments,
+                        customFieldDefinitions: customFieldDefinitions,
+                        titleController: _titleController,
+                        timeSigController: _timeSigController,
+                        keySigController: _keySigController,
+                        notesController: _notesController,
+                        artistInputController: _artistInputController,
+                      )
+                    : const _LoadingView(),
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _handleSaveState(EditNotationSaveState state) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      switch (state) {
+        case EditNotationSaveDone():
+          // Pop all edit screens back to the caller (NotationDetailScreen).
+          Navigator.of(context).popUntil((route) => route.isFirst);
+        case EditNotationSaveError(:final message):
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Could not save: $message'),
+            ),
+          );
+          context.read<EditNotationViewModel>().clearSaveError();
+        case EditNotationSaveIdle():
+        case EditNotationSaving():
+          break;
+      }
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Save button
+// ---------------------------------------------------------------------------
+
+/// AppBar action button that triggers the edit save.
+class _EditSaveButton extends StatelessWidget {
+  const _EditSaveButton({required this.enabled, required this.isSaving});
+
+  final bool enabled;
+  final bool isSaving;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Save changes',
+      button: true,
+      child: isSaving
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : FilledButton(
+              onPressed: enabled ? () => _save(context) : null,
+              child: const Text('Save'),
+            ),
+    );
+  }
+
+  void _save(BuildContext context) {
+    final editVm = context.read<EditNotationViewModel>();
+    final sessionVm = context.read<CaptureSessionViewModel>();
+
+    // Build the updated NotationPage list from the current session.
+    // Each CapturePageDraft carries the mutated RenderParams; we match them
+    // back to the original page ids via positional order (pages cannot be
+    // added or removed in this flow — only their RenderParams change).
+    final existingPages = editVm.existingPages;
+    final sessionPages = sessionVm.pages;
+
+    final updatedPages = <NotationPage>[];
+    for (var i = 0; i < existingPages.length; i++) {
+      final original = existingPages[i];
+      final renderParams = i < sessionPages.length
+          ? sessionPages[i].renderParams
+          : RenderParams.identity;
+
+      updatedPages.add(
+        original.copyWith(
+          renderParams: jsonEncode(renderParams.toJson()),
+        ),
+      );
+    }
+
+    editVm.save(updatedPages: updatedPages);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loading and error views
+// ---------------------------------------------------------------------------
+
+/// Centered loading indicator while dependencies are loading.
+class _LoadingView extends StatelessWidget {
+  const _LoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+/// Error view shown when dependency streams emit an error.
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: cs.error),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load form data',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: cs.error,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Form body
+// ---------------------------------------------------------------------------
+
+/// Scrollable form with all metadata fields, driven by [EditNotationViewModel].
+class _EditFormBody extends StatelessWidget {
+  const _EditFormBody({
+    required this.tags,
+    required this.instruments,
+    required this.customFieldDefinitions,
+    required this.titleController,
+    required this.timeSigController,
+    required this.keySigController,
+    required this.notesController,
+    required this.artistInputController,
+  });
+
+  final List<Tag> tags;
+  final List<InstrumentInstance> instruments;
+  final List<CustomFieldDefinition> customFieldDefinitions;
+  final TextEditingController titleController;
+  final TextEditingController timeSigController;
+  final TextEditingController keySigController;
+  final TextEditingController notesController;
+  final TextEditingController artistInputController;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<EditNotationViewModel>();
+    final fs = vm.formState;
+
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: _kMaxFormWidth),
+        child: ListView(
+          padding: _kFormPadding,
+          children: [
+            _EditTitleField(controller: titleController),
+            const SizedBox(height: _kSectionGap),
+
+            _EditArtistChipInput(
+              artists: fs.artists,
+              inputController: artistInputController,
+            ),
+            const SizedBox(height: _kSectionGap),
+
+            _EditDateField(currentValue: fs.dateWritten),
+            const SizedBox(height: _kSectionGap),
+
+            _EditTextFormRow(
+              label: 'Time signature',
+              hint: 'e.g. 4/4, 6/8',
+              controller: timeSigController,
+              onChanged: vm.setTimeSig,
+            ),
+            const SizedBox(height: _kSectionGap),
+
+            _EditTextFormRow(
+              label: 'Key signature',
+              hint: 'e.g. C major, Yaman',
+              controller: keySigController,
+              onChanged: vm.setKeySig,
+            ),
+            const SizedBox(height: _kSectionGap),
+
+            _EditLanguageChips(selected: fs.languages),
+            const SizedBox(height: _kSectionGap),
+
+            if (tags.isNotEmpty) ...[
+              _EditTagChips(tags: tags, selectedIds: fs.selectedTagIds),
+              const SizedBox(height: _kSectionGap),
+            ],
+
+            if (instruments.isNotEmpty) ...[
+              _EditInstrumentChips(
+                instruments: instruments,
+                selectedIds: fs.selectedInstrumentIds,
+              ),
+              const SizedBox(height: _kSectionGap),
+            ],
+
+            _EditNotesField(controller: notesController),
+            const SizedBox(height: _kSectionGap),
+
+            if (customFieldDefinitions.isNotEmpty)
+              _EditCustomFieldsSection(definitions: customFieldDefinitions),
+
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Title field
+// ---------------------------------------------------------------------------
+
+/// Required title text field wired to [EditNotationViewModel].
+class _EditTitleField extends StatelessWidget {
+  const _EditTitleField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return TextField(
+      controller: controller,
+      decoration: const InputDecoration(
+        labelText: 'Title',
+        border: OutlineInputBorder(),
+        hintText: 'Notation title',
+      ),
+      textCapitalization: TextCapitalization.sentences,
+      onChanged: vm.setTitle,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Artist chip input
+// ---------------------------------------------------------------------------
+
+/// Chip input row for adding and removing artist names.
+class _EditArtistChipInput extends StatelessWidget {
+  const _EditArtistChipInput({
+    required this.artists,
+    required this.inputController,
+  });
+
+  final List<String> artists;
+  final TextEditingController inputController;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Artist(s)', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: _kLabelGap),
+        if (artists.isNotEmpty)
+          Wrap(
+            spacing: _kChipSpacing,
+            runSpacing: _kChipSpacing,
+            children: [
+              for (var i = 0; i < artists.length; i++)
+                InputChip(
+                  label: Text(artists[i]),
+                  onDeleted: () => vm.removeArtist(i),
+                  deleteIconColor:
+                      Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            ],
+          ),
+        if (artists.isNotEmpty) const SizedBox(height: _kLabelGap),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: inputController,
+                decoration: const InputDecoration(
+                  hintText: 'Add artist',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                textCapitalization: TextCapitalization.words,
+                onSubmitted: (value) {
+                  vm.addArtist(value);
+                  inputController.clear();
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton.filled(
+              onPressed: () {
+                vm.addArtist(inputController.text);
+                inputController.clear();
+              },
+              icon: const Icon(Icons.add),
+              tooltip: 'Add artist',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Date field
+// ---------------------------------------------------------------------------
+
+/// Date picker row for the "Date written" field.
+class _EditDateField extends StatelessWidget {
+  const _EditDateField({required this.currentValue});
+
+  final String? currentValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    final label = currentValue ?? 'Pick a date';
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            'Date written: $label',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+        TextButton.icon(
+          onPressed: () => _pickDate(context, vm),
+          icon: const Icon(Icons.calendar_today_outlined),
+          label: const Text('Select'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pickDate(
+    BuildContext context,
+    EditNotationViewModel vm,
+  ) async {
+    final initial = currentValue != null
+        ? DateTime.tryParse(currentValue!) ?? DateTime.now()
+        : DateTime.now();
+
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100),
+    );
+
+    if (picked == null) return;
+    vm.setDateWritten(
+      '${picked.year.toString().padLeft(4, '0')}-'
+      '${picked.month.toString().padLeft(2, '0')}-'
+      '${picked.day.toString().padLeft(2, '0')}',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic text form row
+// ---------------------------------------------------------------------------
+
+/// Labelled text field row (time sig, key sig).
+class _EditTextFormRow extends StatelessWidget {
+  const _EditTextFormRow({
+    required this.label,
+    required this.hint,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final String label;
+  final String hint;
+  final TextEditingController controller;
+  final void Function(String) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: onChanged,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Language chips
+// ---------------------------------------------------------------------------
+
+/// Multi-select filter chips for language selection.
+class _EditLanguageChips extends StatelessWidget {
+  const _EditLanguageChips({required this.selected});
+
+  final List<String> selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Language', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: _kLabelGap),
+        Wrap(
+          spacing: _kChipSpacing,
+          runSpacing: _kChipSpacing,
+          children: kMetadataFormLanguages.map((lang) {
+            final isSelected = selected.contains(lang);
+            return FilterChip(
+              label: Text(lang),
+              selected: isSelected,
+              onSelected: (_) => vm.toggleLanguage(lang),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag chips
+// ---------------------------------------------------------------------------
+
+/// Multi-select filter chips for tag selection.
+class _EditTagChips extends StatelessWidget {
+  const _EditTagChips({required this.tags, required this.selectedIds});
+
+  final List<Tag> tags;
+  final List<String> selectedIds;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Tags', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: _kLabelGap),
+        Wrap(
+          spacing: _kChipSpacing,
+          runSpacing: _kChipSpacing,
+          children: tags.map((tag) {
+            final isSelected = selectedIds.contains(tag.id);
+            return FilterChip(
+              label: Text(tag.name),
+              selected: isSelected,
+              onSelected: (_) => vm.toggleTag(tag.id),
+              avatar: CircleAvatar(
+                backgroundColor: _colorFromHex(tag.colorHex),
+                radius: 8,
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instrument chips
+// ---------------------------------------------------------------------------
+
+/// Multi-select filter chips for instrument selection.
+class _EditInstrumentChips extends StatelessWidget {
+  const _EditInstrumentChips({
+    required this.instruments,
+    required this.selectedIds,
+  });
+
+  final List<InstrumentInstance> instruments;
+  final List<String> selectedIds;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Instruments', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: _kLabelGap),
+        Wrap(
+          spacing: _kChipSpacing,
+          runSpacing: _kChipSpacing,
+          children: instruments.map((inst) {
+            final isSelected = selectedIds.contains(inst.id);
+            final label = _instanceLabel(inst);
+            return FilterChip(
+              label: Text(label),
+              selected: isSelected,
+              onSelected: (_) => vm.toggleInstrument(inst.id),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  String _instanceLabel(InstrumentInstance inst) {
+    final parts = [inst.brand, inst.model].whereType<String>().toList();
+    if (parts.isNotEmpty) return parts.join(' ');
+    return 'Instrument ${inst.id.substring(0, 4)}';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notes field
+// ---------------------------------------------------------------------------
+
+/// Multiline text field for personal notes.
+class _EditNotesField extends StatelessWidget {
+  const _EditNotesField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return TextField(
+      controller: controller,
+      decoration: const InputDecoration(
+        labelText: 'Personal notes',
+        border: OutlineInputBorder(),
+        alignLabelWithHint: true,
+      ),
+      maxLines: 4,
+      textCapitalization: TextCapitalization.sentences,
+      onChanged: vm.setNotes,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Custom fields section
+// ---------------------------------------------------------------------------
+
+/// Dynamically rendered inputs for each [CustomFieldDefinition].
+class _EditCustomFieldsSection extends StatelessWidget {
+  const _EditCustomFieldsSection({required this.definitions});
+
+  final List<CustomFieldDefinition> definitions;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Custom fields',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: _kLabelGap),
+        ...definitions.map(
+          (def) => Padding(
+            padding: const EdgeInsets.only(bottom: _kSectionGap),
+            child: _EditCustomFieldInput(definition: def),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A single custom field input rendered by its type.
+class _EditCustomFieldInput extends StatelessWidget {
+  const _EditCustomFieldInput({required this.definition});
+
+  final CustomFieldDefinition definition;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (definition.fieldType) {
+      CustomFieldType.text =>
+        _EditCustomTextInput(definition: definition),
+      CustomFieldType.number =>
+        _EditCustomNumberInput(definition: definition),
+      CustomFieldType.date =>
+        _EditCustomDateInput(definition: definition),
+      CustomFieldType.boolean =>
+        _EditCustomBooleanInput(definition: definition),
+    };
+  }
+}
+
+class _EditCustomTextInput extends StatefulWidget {
+  const _EditCustomTextInput({required this.definition});
+
+  final CustomFieldDefinition definition;
+
+  @override
+  State<_EditCustomTextInput> createState() => _EditCustomTextInputState();
+}
+
+class _EditCustomTextInputState extends State<_EditCustomTextInput> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final existing = context
+            .read<EditNotationViewModel>()
+            .formState
+            .customFieldValues[widget.definition.id]
+            ?.textValue ??
+        '';
+    _controller = TextEditingController(text: existing);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return TextField(
+      controller: _controller,
+      decoration: InputDecoration(
+        labelText: widget.definition.keyName,
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (v) => vm.setCustomFieldText(widget.definition.id, v),
+    );
+  }
+}
+
+class _EditCustomNumberInput extends StatefulWidget {
+  const _EditCustomNumberInput({required this.definition});
+
+  final CustomFieldDefinition definition;
+
+  @override
+  State<_EditCustomNumberInput> createState() => _EditCustomNumberInputState();
+}
+
+class _EditCustomNumberInputState extends State<_EditCustomNumberInput> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final existing = context
+        .read<EditNotationViewModel>()
+        .formState
+        .customFieldValues[widget.definition.id]
+        ?.numberValue;
+    _controller = TextEditingController(
+      text: existing != null ? existing.toString() : '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<EditNotationViewModel>();
+    return TextField(
+      controller: _controller,
+      decoration: InputDecoration(
+        labelText: widget.definition.keyName,
+        border: const OutlineInputBorder(),
+      ),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      onChanged: (v) {
+        final n = double.tryParse(v);
+        if (n != null) vm.setCustomFieldNumber(widget.definition.id, n);
+      },
+    );
+  }
+}
+
+class _EditCustomDateInput extends StatelessWidget {
+  const _EditCustomDateInput({required this.definition});
+
+  final CustomFieldDefinition definition;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<EditNotationViewModel>();
+    final existing =
+        vm.formState.customFieldValues[definition.id]?.dateValue;
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            '${definition.keyName}: ${existing ?? 'Not set'}',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+        TextButton.icon(
+          onPressed: () => _pickDate(context, vm),
+          icon: const Icon(Icons.calendar_today_outlined),
+          label: const Text('Select'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pickDate(
+    BuildContext context,
+    EditNotationViewModel vm,
+  ) async {
+    final existing =
+        vm.formState.customFieldValues[definition.id]?.dateValue;
+    final initial = existing != null
+        ? DateTime.tryParse(existing) ?? DateTime.now()
+        : DateTime.now();
+
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100),
+    );
+
+    if (picked == null) return;
+    vm.setCustomFieldDate(
+      definition.id,
+      '${picked.year.toString().padLeft(4, '0')}-'
+      '${picked.month.toString().padLeft(2, '0')}-'
+      '${picked.day.toString().padLeft(2, '0')}',
+    );
+  }
+}
+
+class _EditCustomBooleanInput extends StatelessWidget {
+  const _EditCustomBooleanInput({required this.definition});
+
+  final CustomFieldDefinition definition;
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<EditNotationViewModel>();
+    final value =
+        vm.formState.customFieldValues[definition.id]?.booleanValue ?? false;
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            definition.keyName,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+        Switch(
+          value: value,
+          onChanged: (v) =>
+              vm.setCustomFieldBoolean(definition.id, value: v),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// No-op stubs for MetadataFormViewModel constructor requirements
+// ---------------------------------------------------------------------------
+
+/// No-op [NotationRepository] used solely to satisfy [MetadataFormViewModel]
+/// constructor when the ViewModel is used only for dependency loading.
+class _NoopNotationRepository implements NotationRepository {
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) =>
+      throw UnimplementedError();
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async => null;
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<void> softDelete(String id) async {}
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
+}
+
+/// No-op [FileStorageService] used solely to satisfy [MetadataFormViewModel]
+/// constructor when the ViewModel is used only for dependency loading.
+class _NoopFileStorageService extends FileStorageService {}
+
+// ---------------------------------------------------------------------------
+// Color helper
+// ---------------------------------------------------------------------------
+
+/// Parses a `'#RRGGBB'` hex string into a [Color].
+///
+/// Returns [Colors.grey] if the string is malformed.
+Color _colorFromHex(String hex) {
+  try {
+    final cleaned = hex.replaceFirst('#', '');
+    if (cleaned.length != 6) return Colors.grey;
+    return Color(int.parse('FF$cleaned', radix: 16));
+  } on FormatException {
+    return Colors.grey;
+  }
+}

--- a/lib/features/edit/screens/edit_notation_screen.dart
+++ b/lib/features/edit/screens/edit_notation_screen.dart
@@ -1,0 +1,363 @@
+// edit_notation_screen.dart — Orchestration screen for the edit-notation flow.
+//
+// Route: push-only (not registered in GoRouter yet; launched via
+//   Navigator.push from LibraryScreen or NotationDetailScreen)
+//
+// Flow:
+//   EditNotationScreen (loads existing notation)
+//     → PageEditorScreen (adjust per-page render params)
+//       → EditMetadataFormScreen (update metadata)
+//         → [pop to NotationDetailScreen]
+//
+// The screen owns and provides three ViewModels:
+//   - [EditNotationViewModel]: loads the notation and persists changes.
+//   - [CaptureSessionViewModel]: holds the in-memory page list used by the
+//     page editor. Pre-populated from [EditNotationViewModel.existingPages]
+//     paths via [FileReader] after load completes.
+//   - [PageEditorViewModel]: wraps [CaptureSessionViewModel] for per-page
+//     editing (filter, rotate, crop, reorder).
+//
+// On "Save" from the metadata form, the screen calls
+// [EditNotationViewModel.save] with the updated pages from the session and
+// navigates back to [NotationDetailScreen] via [Navigator.popUntil].
+
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/capture/models/capture_page_draft.dart';
+import 'package:swaralipi/features/capture/viewmodels/capture_session_view_model.dart';
+import 'package:swaralipi/features/capture/viewmodels/page_editor_view_model.dart';
+import 'package:swaralipi/features/capture/screens/page_editor_screen.dart';
+import 'package:swaralipi/features/edit/screens/edit_metadata_form_screen.dart';
+import 'package:swaralipi/features/edit/viewmodels/edit_notation_view_model.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/render_params.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Orchestration screen that drives the edit-notation flow.
+///
+/// Loads the existing [NotationDetail] via [EditNotationViewModel], then
+/// transitions through [PageEditorScreen] and [EditMetadataFormScreen].
+/// On completion, pops back to the caller (typically [NotationDetailScreen]).
+///
+/// Dependencies are injected at the call site via [create] factories in
+/// [ChangeNotifierProvider] widgets.
+class EditNotationScreen extends StatefulWidget {
+  /// Creates an [EditNotationScreen] for the notation with [notationId].
+  ///
+  /// Parameters:
+  /// - [notationId]: UUIDv4 of the notation to edit.
+  /// - [notationRepository]: Used to load and update the notation.
+  /// - [tagRepository]: Source of truth for tags (needed by metadata form).
+  /// - [instrumentRepository]: Source of truth for instruments.
+  /// - [customFieldRepository]: Source of truth for custom field definitions.
+  /// - [fileStorageService]: Resolves stored relative paths to absolute paths.
+  const EditNotationScreen({
+    required this.notationId,
+    required this.notationRepository,
+    required this.tagRepository,
+    required this.instrumentRepository,
+    required this.customFieldRepository,
+    required this.fileStorageService,
+    super.key,
+  });
+
+  /// UUIDv4 of the notation to edit.
+  final String notationId;
+
+  /// Used to load and update the notation.
+  final NotationRepository notationRepository;
+
+  /// Source of truth for tags, passed to [EditMetadataFormScreen].
+  final TagRepository tagRepository;
+
+  /// Source of truth for instruments, passed to [EditMetadataFormScreen].
+  final InstrumentRepository instrumentRepository;
+
+  /// Source of truth for custom field definitions.
+  final CustomFieldRepository customFieldRepository;
+
+  /// Resolves stored relative paths to absolute paths for the page editor.
+  final FileStorageService fileStorageService;
+
+  @override
+  State<EditNotationScreen> createState() => _EditNotationScreenState();
+}
+
+class _EditNotationScreenState extends State<EditNotationScreen> {
+  late final EditNotationViewModel _editVm;
+  late final CaptureSessionViewModel _sessionVm;
+  late final PageEditorViewModel _pageEditorVm;
+
+  @override
+  void initState() {
+    super.initState();
+    _editVm = EditNotationViewModel(
+      notationRepository: widget.notationRepository,
+    );
+    _sessionVm = CaptureSessionViewModel();
+    _pageEditorVm = PageEditorViewModel(session: _sessionVm);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _loadNotation();
+    });
+  }
+
+  Future<void> _loadNotation() async {
+    await _editVm.loadNotation(widget.notationId);
+    if (!mounted) return;
+
+    if (_editVm.state is EditNotationStateSuccess) {
+      await _populateSession(_editVm.existingPages);
+    }
+  }
+
+  /// Reads each existing page's image bytes from disk and loads them into
+  /// [_sessionVm] so [PageEditorScreen] can render them.
+  ///
+  /// Uses [FileStorageService.getAbsolutePath] to resolve relative paths.
+  Future<void> _populateSession(List<NotationPage> pages) async {
+    final drafts = <CapturePageDraft>[];
+    for (final page in pages) {
+      try {
+        final absPath = await widget.fileStorageService
+            .getAbsolutePath(page.imagePath);
+        final bytes = await File(absPath).readAsBytes();
+        final renderParams = _parseRenderParams(page.renderParams);
+        drafts.add(
+          CapturePageDraft(
+            originalPath: absPath,
+            originalBytes: bytes,
+            renderParams: renderParams,
+          ),
+        );
+      } on Exception catch (e, st) {
+        log(
+          'EditNotationScreen: could not load page "${page.id}": $e',
+          name: 'EditNotationScreen',
+          error: e,
+          stackTrace: st,
+        );
+      }
+    }
+    _sessionVm.replacePages(drafts);
+  }
+
+  RenderParams _parseRenderParams(String json) {
+    try {
+      final decoded = jsonDecode(json);
+      if (decoded is Map<String, dynamic>) {
+        return RenderParams.fromJson(decoded);
+      }
+    } on FormatException catch (e) {
+      log(
+        'EditNotationScreen: failed to parse renderParams "$json": $e',
+        name: 'EditNotationScreen',
+      );
+    }
+    return RenderParams.identity;
+  }
+
+  @override
+  void dispose() {
+    _pageEditorVm.dispose();
+    _sessionVm.dispose();
+    _editVm.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<EditNotationViewModel>.value(value: _editVm),
+        ChangeNotifierProvider<CaptureSessionViewModel>.value(value: _sessionVm),
+        ChangeNotifierProvider<PageEditorViewModel>.value(value: _pageEditorVm),
+      ],
+      child: const _EditNotationBody(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body
+// ---------------------------------------------------------------------------
+
+/// Renders the correct state for the edit flow.
+class _EditNotationBody extends StatelessWidget {
+  const _EditNotationBody();
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<EditNotationViewModel>();
+
+    return switch (vm.state) {
+      EditNotationStateIdle() ||
+      EditNotationStateLoading() =>
+        const _LoadingScaffold(),
+      EditNotationStateNotFound() => const _NotFoundScaffold(),
+      EditNotationStateError(:final message) =>
+        _ErrorScaffold(message: message),
+      EditNotationStateSuccess() => _EditFlowScaffold(editVm: vm),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Edit flow scaffold
+// ---------------------------------------------------------------------------
+
+/// Main scaffold once the notation is loaded.
+///
+/// Presents [PageEditorScreen]; on "Next", navigates to
+/// [EditMetadataFormScreen].
+class _EditFlowScaffold extends StatelessWidget {
+  const _EditFlowScaffold({required this.editVm});
+
+  final EditNotationViewModel editVm;
+
+  @override
+  Widget build(BuildContext context) {
+    return PageEditorScreen(
+      onNext: (context) => _navigateToMetadataForm(context),
+    );
+  }
+
+  void _navigateToMetadataForm(BuildContext context) {
+    final editVmLocal = context.read<EditNotationViewModel>();
+    final sessionVm = context.read<CaptureSessionViewModel>();
+    final screen = context.findAncestorWidgetOfExactType<EditNotationScreen>();
+    if (screen == null) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => MultiProvider(
+          providers: [
+            ChangeNotifierProvider<EditNotationViewModel>.value(
+              value: editVmLocal,
+            ),
+            ChangeNotifierProvider<CaptureSessionViewModel>.value(
+              value: sessionVm,
+            ),
+          ],
+          child: EditMetadataFormScreen(
+            notationId: editVmLocal.state is EditNotationStateSuccess
+                ? (editVmLocal.state as EditNotationStateSuccess).notationId
+                : '',
+            tagRepository: screen.tagRepository,
+            instrumentRepository: screen.instrumentRepository,
+            customFieldRepository: screen.customFieldRepository,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loading / error / not-found scaffolds
+// ---------------------------------------------------------------------------
+
+/// Loading scaffold shown while the notation is being fetched.
+class _LoadingScaffold extends StatelessWidget {
+  const _LoadingScaffold();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Notation')),
+      body: const Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+
+/// Scaffold shown when the notation id does not exist.
+class _NotFoundScaffold extends StatelessWidget {
+  const _NotFoundScaffold();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Notation')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.search_off_outlined,
+                size: 48,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Notation not found',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Scaffold shown when loading fails with an exception.
+class _ErrorScaffold extends StatelessWidget {
+  const _ErrorScaffold({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Notation')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline,
+                size: 48,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Failed to load notation',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                message,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/edit/viewmodels/edit_notation_view_model.dart
+++ b/lib/features/edit/viewmodels/edit_notation_view_model.dart
@@ -1,0 +1,591 @@
+// edit_notation_view_model.dart — ChangeNotifier ViewModel for editing an
+// existing notation.
+//
+// Orchestrates the two-step edit flow:
+//   1. [loadNotation] fetches the existing [NotationDetail] from the repository
+//      and pre-populates [formState] with its metadata and [existingPages] with
+//      its pages.
+//   2. [save] assembles a [NotationDraft] from the mutated [formState] and
+//      calls [NotationRepository.updateNotation], persisting only metadata changes.
+//      Page render-param changes are persisted via the [updatedPages] list
+//      which maps to the [NotationPage.renderParams] column.
+//
+// Architecture note:
+//   View → EditNotationViewModel → NotationRepository
+//
+// The ViewModel is intentionally separate from [MetadataFormViewModel] so that
+// the edit flow can share the same [MetadataFormScreen] and [PageEditorScreen]
+// widgets without adding edit-mode coupling to the capture flow.
+//
+// Lifecycle:
+//   Call [loadNotation] once from the screen's initState /
+//   didChangeDependencies. Dispose is handled by ChangeNotifier.
+
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:swaralipi/features/capture/viewmodels/metadata_form_view_model.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Load state
+// ---------------------------------------------------------------------------
+
+/// Sealed state for the notation-loading phase of the edit flow.
+///
+/// Variants: [EditNotationStateIdle], [EditNotationStateLoading],
+/// [EditNotationStateSuccess], [EditNotationStateNotFound],
+/// [EditNotationStateError].
+sealed class EditNotationState {
+  /// Creates an [EditNotationState].
+  const EditNotationState();
+}
+
+/// Initial state before [EditNotationViewModel.loadNotation] is called.
+final class EditNotationStateIdle extends EditNotationState {
+  /// Creates an [EditNotationStateIdle].
+  const EditNotationStateIdle();
+}
+
+/// State while the notation is being fetched from the repository.
+final class EditNotationStateLoading extends EditNotationState {
+  /// Creates an [EditNotationStateLoading].
+  const EditNotationStateLoading();
+}
+
+/// State when the notation was loaded and pre-population is complete.
+final class EditNotationStateSuccess extends EditNotationState {
+  /// Creates an [EditNotationStateSuccess].
+  ///
+  /// Parameters:
+  /// - [notationId]: UUIDv4 of the loaded notation.
+  const EditNotationStateSuccess({required this.notationId});
+
+  /// UUIDv4 of the loaded notation.
+  final String notationId;
+}
+
+/// State when the notation id does not exist in the repository.
+final class EditNotationStateNotFound extends EditNotationState {
+  /// Creates an [EditNotationStateNotFound].
+  const EditNotationStateNotFound();
+}
+
+/// State when loading fails with an exception.
+final class EditNotationStateError extends EditNotationState {
+  /// Creates an [EditNotationStateError].
+  ///
+  /// Parameters:
+  /// - [message]: Human-readable error description.
+  const EditNotationStateError({required this.message});
+
+  /// Human-readable error description.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// Save state
+// ---------------------------------------------------------------------------
+
+/// Sealed state for the notation-save phase of the edit flow.
+///
+/// Variants: [EditNotationSaveIdle], [EditNotationSaving],
+/// [EditNotationSaveDone], [EditNotationSaveError].
+sealed class EditNotationSaveState {
+  /// Creates an [EditNotationSaveState].
+  const EditNotationSaveState();
+}
+
+/// Initial state; no save has been attempted.
+final class EditNotationSaveIdle extends EditNotationSaveState {
+  /// Creates an [EditNotationSaveIdle].
+  const EditNotationSaveIdle();
+}
+
+/// A save operation is in progress.
+final class EditNotationSaving extends EditNotationSaveState {
+  /// Creates an [EditNotationSaving].
+  const EditNotationSaving();
+}
+
+/// The notation was updated successfully.
+final class EditNotationSaveDone extends EditNotationSaveState {
+  /// Creates an [EditNotationSaveDone].
+  ///
+  /// Parameters:
+  /// - [notationId]: UUIDv4 of the updated notation.
+  const EditNotationSaveDone({required this.notationId});
+
+  /// UUIDv4 of the updated notation.
+  final String notationId;
+}
+
+/// The save operation failed.
+final class EditNotationSaveError extends EditNotationSaveState {
+  /// Creates an [EditNotationSaveError].
+  ///
+  /// Parameters:
+  /// - [message]: Human-readable error description.
+  const EditNotationSaveError({required this.message});
+
+  /// Human-readable error description.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/// ChangeNotifier ViewModel that manages loading and saving an existing
+/// notation in the edit flow.
+///
+/// On [loadNotation], fetches the [NotationDetail] and pre-populates
+/// [formState] and [existingPages] so the edit screens show current values.
+///
+/// On [save], assembles a [NotationDraft] from [formState] and calls
+/// [NotationRepository.updateNotation].  Page-level [RenderParams] changes
+/// arrive via the [updatedPages] parameter and are persisted separately
+/// through the repository's page-replace mechanism (not implemented here —
+/// the caller is responsible for passing pages that already have updated
+/// [NotationPage.renderParams] values; this ViewModel stores them in
+/// [existingPages] so the page editor screen can read them).
+///
+/// Dependencies are injected via constructor; no [BuildContext] references.
+class EditNotationViewModel extends ChangeNotifier {
+  /// Creates an [EditNotationViewModel].
+  ///
+  /// Parameters:
+  /// - [notationRepository]: Used to load and update the notation.
+  EditNotationViewModel({required NotationRepository notationRepository})
+      : _notationRepository = notationRepository;
+
+  final NotationRepository _notationRepository;
+
+  EditNotationState _state = const EditNotationStateIdle();
+  EditNotationSaveState _saveState = const EditNotationSaveIdle();
+  MetadataFormFormState _formState = const MetadataFormFormState();
+  List<NotationPage> _existingPages = const [];
+  String? _notationId;
+
+  // -------------------------------------------------------------------------
+  // Public getters
+  // -------------------------------------------------------------------------
+
+  /// The current load state.
+  EditNotationState get state => _state;
+
+  /// The current save state.
+  EditNotationSaveState get saveState => _saveState;
+
+  /// The current form field values, pre-populated after [loadNotation].
+  MetadataFormFormState get formState => _formState;
+
+  /// The pages belonging to the loaded notation, pre-populated after
+  /// [loadNotation].
+  ///
+  /// Returns an unmodifiable view. Callers hand these to [PageEditorScreen]
+  /// as the initial page set for the edit session.
+  List<NotationPage> get existingPages => List.unmodifiable(_existingPages);
+
+  /// Whether the title field contains a non-empty, non-whitespace string.
+  bool get isTitleValid => _formState.title.trim().isNotEmpty;
+
+  // -------------------------------------------------------------------------
+  // Load
+  // -------------------------------------------------------------------------
+
+  /// Loads the notation with [id] and pre-populates [formState] and
+  /// [existingPages].
+  ///
+  /// Transitions:
+  ///   [EditNotationStateIdle] → [EditNotationStateLoading] →
+  ///   [EditNotationStateSuccess] (found) |
+  ///   [EditNotationStateNotFound] (null return) |
+  ///   [EditNotationStateError] (exception)
+  ///
+  /// Calling [loadNotation] again resets all state.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the notation to load.
+  Future<void> loadNotation(String id) async {
+    _state = const EditNotationStateLoading();
+    _formState = const MetadataFormFormState();
+    _existingPages = const [];
+    _notationId = null;
+    notifyListeners();
+
+    try {
+      final detail = await _notationRepository.loadNotation(id);
+      if (detail == null) {
+        _state = const EditNotationStateNotFound();
+        notifyListeners();
+        return;
+      }
+
+      _notationId = detail.notation.id;
+      _formState = _buildFormState(detail);
+      _existingPages = List.unmodifiable(detail.pages);
+      _state = EditNotationStateSuccess(notationId: detail.notation.id);
+
+      log(
+        'EditNotationViewModel: loaded notation "${detail.notation.id}"',
+        name: 'EditNotationViewModel',
+      );
+    } on Exception catch (e, st) {
+      log(
+        'EditNotationViewModel: loadNotation failed — $e',
+        name: 'EditNotationViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _state = EditNotationStateError(message: e.toString());
+    }
+
+    notifyListeners();
+  }
+
+  /// Builds a pre-populated [MetadataFormFormState] from [detail].
+  MetadataFormFormState _buildFormState(NotationDetail detail) {
+    final notation = detail.notation;
+
+    final tagIds = detail.tags.map((t) => t.id).toList();
+
+    final customFields = <String, CustomFieldEntry>{};
+    for (final cfv in detail.customFieldValues) {
+      customFields[cfv.definitionId] = CustomFieldEntry(
+        definitionId: cfv.definitionId,
+        textValue: cfv.valueText,
+        numberValue: cfv.valueNumber,
+        dateValue: cfv.valueDate,
+        booleanValue: cfv.valueBoolean,
+      );
+    }
+
+    return MetadataFormFormState(
+      title: notation.title,
+      artists: List<String>.from(notation.artists),
+      dateWritten: notation.dateWritten,
+      timeSig: notation.timeSig,
+      keySig: notation.keySig,
+      languages: List<String>.from(notation.languages),
+      notes: notation.notes,
+      selectedTagIds: tagIds,
+      customFieldValues: customFields,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Form field setters
+  // -------------------------------------------------------------------------
+
+  /// Updates the title field.
+  ///
+  /// Parameters:
+  /// - [value]: The new title string.
+  void setTitle(String value) {
+    _formState = _formState.copyWith(title: value);
+    notifyListeners();
+  }
+
+  /// Updates the date written field.
+  ///
+  /// Parameters:
+  /// - [value]: ISO 8601 date string (YYYY-MM-DD).
+  void setDateWritten(String value) {
+    _formState = _formState.copyWith(dateWritten: value);
+    notifyListeners();
+  }
+
+  /// Updates the time signature field.
+  ///
+  /// Parameters:
+  /// - [value]: Time signature string, e.g. `'4/4'`.
+  void setTimeSig(String value) {
+    _formState = _formState.copyWith(timeSig: value);
+    notifyListeners();
+  }
+
+  /// Updates the key signature field.
+  ///
+  /// Parameters:
+  /// - [value]: Key signature string, e.g. `'C major'`.
+  void setKeySig(String value) {
+    _formState = _formState.copyWith(keySig: value);
+    notifyListeners();
+  }
+
+  /// Updates the personal notes field.
+  ///
+  /// Parameters:
+  /// - [value]: Free-form text.
+  void setNotes(String value) {
+    _formState = _formState.copyWith(notes: value);
+    notifyListeners();
+  }
+
+  /// Appends a trimmed artist name to the artists list.
+  ///
+  /// Blank (whitespace-only) values are ignored.
+  ///
+  /// Parameters:
+  /// - [name]: Artist name to add.
+  void addArtist(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return;
+    _formState = _formState.copyWith(
+      artists: [..._formState.artists, trimmed],
+    );
+    notifyListeners();
+  }
+
+  /// Removes the artist at [index] from the list.
+  ///
+  /// Parameters:
+  /// - [index]: 0-based position of the artist to remove.
+  void removeArtist(int index) {
+    final updated = List<String>.from(_formState.artists)..removeAt(index);
+    _formState = _formState.copyWith(artists: updated);
+    notifyListeners();
+  }
+
+  /// Toggles [language] in the selected languages list.
+  ///
+  /// Adds [language] if not present; removes it if already selected.
+  ///
+  /// Parameters:
+  /// - [language]: Language name, e.g. `'Hindi'`.
+  void toggleLanguage(String language) {
+    final current = List<String>.from(_formState.languages);
+    if (current.contains(language)) {
+      current.remove(language);
+    } else {
+      current.add(language);
+    }
+    _formState = _formState.copyWith(languages: current);
+    notifyListeners();
+  }
+
+  /// Toggles [id] in the selected tag ids list.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the tag to toggle.
+  void toggleTag(String id) {
+    final current = List<String>.from(_formState.selectedTagIds);
+    if (current.contains(id)) {
+      current.remove(id);
+    } else {
+      current.add(id);
+    }
+    _formState = _formState.copyWith(selectedTagIds: current);
+    notifyListeners();
+  }
+
+  /// Toggles [id] in the selected instrument ids list.
+  ///
+  /// Parameters:
+  /// - [id]: UUIDv4 of the instrument instance to toggle.
+  void toggleInstrument(String id) {
+    final current = List<String>.from(_formState.selectedInstrumentIds);
+    if (current.contains(id)) {
+      current.remove(id);
+    } else {
+      current.add(id);
+    }
+    _formState = _formState.copyWith(selectedInstrumentIds: current);
+    notifyListeners();
+  }
+
+  /// Sets a text value for the custom field identified by [definitionId].
+  ///
+  /// Parameters:
+  /// - [definitionId]: UUIDv4 of the custom field definition.
+  /// - [value]: Text value to store.
+  void setCustomFieldText(String definitionId, String value) {
+    _updateCustomField(
+      definitionId,
+      (e) => e.copyWith(textValue: value),
+      defaultEntry: CustomFieldEntry(
+        definitionId: definitionId,
+        textValue: value,
+      ),
+    );
+  }
+
+  /// Sets a numeric value for the custom field identified by [definitionId].
+  ///
+  /// Parameters:
+  /// - [definitionId]: UUIDv4 of the custom field definition.
+  /// - [value]: Numeric value to store.
+  void setCustomFieldNumber(String definitionId, double value) {
+    _updateCustomField(
+      definitionId,
+      (e) => e.copyWith(numberValue: value),
+      defaultEntry: CustomFieldEntry(
+        definitionId: definitionId,
+        numberValue: value,
+      ),
+    );
+  }
+
+  /// Sets a date value for the custom field identified by [definitionId].
+  ///
+  /// Parameters:
+  /// - [definitionId]: UUIDv4 of the custom field definition.
+  /// - [value]: ISO 8601 date string (YYYY-MM-DD).
+  void setCustomFieldDate(String definitionId, String value) {
+    _updateCustomField(
+      definitionId,
+      (e) => e.copyWith(dateValue: value),
+      defaultEntry: CustomFieldEntry(
+        definitionId: definitionId,
+        dateValue: value,
+      ),
+    );
+  }
+
+  /// Sets a boolean value for the custom field identified by [definitionId].
+  ///
+  /// Parameters:
+  /// - [definitionId]: UUIDv4 of the custom field definition.
+  /// - [value]: Boolean value to store.
+  void setCustomFieldBoolean(String definitionId, {required bool value}) {
+    _updateCustomField(
+      definitionId,
+      (e) => e.copyWith(booleanValue: value),
+      defaultEntry: CustomFieldEntry(
+        definitionId: definitionId,
+        booleanValue: value,
+      ),
+    );
+  }
+
+  void _updateCustomField(
+    String definitionId,
+    CustomFieldEntry Function(CustomFieldEntry) update, {
+    required CustomFieldEntry defaultEntry,
+  }) {
+    final current = Map<String, CustomFieldEntry>.from(
+      _formState.customFieldValues,
+    );
+    final existing = current[definitionId];
+    current[definitionId] = existing != null ? update(existing) : defaultEntry;
+    _formState = _formState.copyWith(customFieldValues: current);
+    notifyListeners();
+  }
+
+  // -------------------------------------------------------------------------
+  // Save
+  // -------------------------------------------------------------------------
+
+  /// Updates the notation in the repository with the current [formState].
+  ///
+  /// No-op if [isTitleValid] is false or a save is already in progress.
+  ///
+  /// The [updatedPages] parameter carries the final ordered list of
+  /// [NotationPage] objects (with potentially mutated [renderParams]) that
+  /// the page editor produced. This ViewModel stores them in [existingPages]
+  /// after a successful save so the caller can navigate with up-to-date data.
+  ///
+  /// On success, transitions to [EditNotationSaveDone] carrying the
+  /// [notationId]. On failure, transitions to [EditNotationSaveError].
+  ///
+  /// Parameters:
+  /// - [updatedPages]: Final ordered list of [NotationPage] objects from the
+  ///   page editor session.
+  Future<void> save({required List<NotationPage> updatedPages}) async {
+    if (!isTitleValid) return;
+    if (_saveState is EditNotationSaving) return;
+
+    final id = _notationId;
+    if (id == null) return;
+
+    _saveState = const EditNotationSaving();
+    notifyListeners();
+
+    try {
+      final draft = _buildDraft();
+      final updated =
+          await _notationRepository.updateNotation(id, draft);
+
+      // Persist any render-param changes for each page in the updated list.
+      for (final page in updatedPages) {
+        await _notationRepository.updatePageRenderParams(
+          page.id,
+          page.renderParams,
+        );
+      }
+
+      if (updatedPages.isNotEmpty) {
+        _existingPages = List.unmodifiable(updatedPages);
+      }
+
+      log(
+        'EditNotationViewModel: updated notation "${updated.id}"',
+        name: 'EditNotationViewModel',
+      );
+
+      _saveState = EditNotationSaveDone(notationId: updated.id);
+    } on Exception catch (e, st) {
+      log(
+        'EditNotationViewModel: save failed — $e',
+        name: 'EditNotationViewModel',
+        error: e,
+        stackTrace: st,
+      );
+      _saveState = EditNotationSaveError(message: e.toString());
+    }
+
+    notifyListeners();
+  }
+
+  /// Resets [saveState] to [EditNotationSaveIdle] after an error has been
+  /// surfaced to the user.
+  ///
+  /// Call this after displaying the error to prevent the same error from
+  /// being shown again on rebuild.
+  void clearSaveError() {
+    if (_saveState is EditNotationSaveError) {
+      _saveState = const EditNotationSaveIdle();
+      notifyListeners();
+    }
+  }
+
+  NotationDraft _buildDraft() {
+    final fs = _formState;
+    final customFields = fs.customFieldValues.entries
+        .map(
+          (entry) => CustomFieldValueInput(
+            definitionId: entry.key,
+            fieldType: _fieldTypeForEntry(entry.value),
+            textValue: entry.value.textValue,
+            numberValue: entry.value.numberValue,
+            dateValue: entry.value.dateValue,
+            booleanValue: entry.value.booleanValue,
+          ),
+        )
+        .toList();
+
+    return NotationDraft(
+      title: fs.title.trim(),
+      artists: fs.artists,
+      dateWritten: fs.dateWritten,
+      timeSig: fs.timeSig,
+      keySig: fs.keySig,
+      languages: fs.languages,
+      notes: fs.notes,
+      tagIds: fs.selectedTagIds,
+      customFields: customFields,
+    );
+  }
+
+  String _fieldTypeForEntry(CustomFieldEntry entry) {
+    if (entry.textValue != null) return 'text';
+    if (entry.numberValue != null) return 'number';
+    if (entry.dateValue != null) return 'date';
+    return 'boolean';
+  }
+}

--- a/lib/features/library/screens/library_screen.dart
+++ b/lib/features/library/screens/library_screen.dart
@@ -12,17 +12,32 @@
 // action appears for 5 seconds. Tapping "Undo" calls
 // [LibraryViewModel.undoDelete].
 //
+// Edit interaction: long-pressing a notation row opens a popup menu with an
+// "Edit" option that launches [EditNotationScreen] via [Navigator.push].
+//
 // Dependencies are injected at the call site:
 //   ChangeNotifierProvider<LibraryViewModel>(
 //     create: (_) => LibraryViewModel(notationRepository, trashRepository),
-//     child: const LibraryScreen(),
+//     child: LibraryScreen(
+//       notationRepository: notationRepository,
+//       tagRepository: tagRepository,
+//       instrumentRepository: instrumentRepository,
+//       customFieldRepository: customFieldRepository,
+//       fileStorageService: fileStorageService,
+//     ),
 //   )
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+import 'package:swaralipi/features/edit/screens/edit_notation_screen.dart';
 import 'package:swaralipi/features/library/viewmodels/library_view_model.dart';
 import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -45,9 +60,42 @@ const EdgeInsets _kSwipeIconPadding = EdgeInsets.symmetric(horizontal: 24);
 ///
 /// Reads [LibraryViewModel] from the widget tree via [ChangeNotifierProvider].
 /// Calls [LibraryViewModel.init] after the first frame.
+///
+/// When the edit dependencies are provided, long-pressing a notation row
+/// reveals a popup menu with an "Edit" option that launches
+/// [EditNotationScreen].
 class LibraryScreen extends StatefulWidget {
   /// Creates a [LibraryScreen].
-  const LibraryScreen({super.key});
+  ///
+  /// Parameters:
+  /// - [notationRepository]: Passed to [EditNotationScreen] when editing.
+  /// - [tagRepository]: Passed to [EditNotationScreen] for the tag picker.
+  /// - [instrumentRepository]: Passed to [EditNotationScreen] for instruments.
+  /// - [customFieldRepository]: Passed to [EditNotationScreen] for custom fields.
+  /// - [fileStorageService]: Passed to [EditNotationScreen] to resolve paths.
+  const LibraryScreen({
+    this.notationRepository,
+    this.tagRepository,
+    this.instrumentRepository,
+    this.customFieldRepository,
+    this.fileStorageService,
+    super.key,
+  });
+
+  /// Used by [EditNotationScreen]. When null the Edit action is hidden.
+  final NotationRepository? notationRepository;
+
+  /// Used by [EditNotationScreen] for the tag picker.
+  final TagRepository? tagRepository;
+
+  /// Used by [EditNotationScreen] for the instrument picker.
+  final InstrumentRepository? instrumentRepository;
+
+  /// Used by [EditNotationScreen] for custom field inputs.
+  final CustomFieldRepository? customFieldRepository;
+
+  /// Used by [EditNotationScreen] to resolve image paths.
+  final FileStorageService? fileStorageService;
 
   @override
   State<LibraryScreen> createState() => _LibraryScreenState();
@@ -76,7 +124,10 @@ class _LibraryScreenState extends State<LibraryScreen> {
         LibraryStateLoading() => const _LoadingView(),
         LibraryStateSuccess(:final notations) => notations.isEmpty
             ? const _EmptyView()
-            : _NotationListView(notations: notations),
+            : _NotationListView(
+                notations: notations,
+                screen: widget,
+              ),
         LibraryStateError(:final message) => _ErrorView(message: message),
       },
     );
@@ -176,16 +227,23 @@ class _ErrorView extends StatelessWidget {
 
 /// Scrollable list of active notation rows.
 class _NotationListView extends StatelessWidget {
-  const _NotationListView({required this.notations});
+  const _NotationListView({
+    required this.notations,
+    required this.screen,
+  });
 
   final List<Notation> notations;
+  final LibraryScreen screen;
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       padding: _kListPadding,
       itemCount: notations.length,
-      itemBuilder: (context, index) => _NotationRow(notation: notations[index]),
+      itemBuilder: (context, index) => _NotationRow(
+        notation: notations[index],
+        screen: screen,
+      ),
     );
   }
 }
@@ -194,14 +252,22 @@ class _NotationListView extends StatelessWidget {
 // Notation row
 // ---------------------------------------------------------------------------
 
-/// A single library row with swipe-to-delete and an undo SnackBar.
+/// A single library row with swipe-to-delete, undo SnackBar, and long-press
+/// edit menu.
 class _NotationRow extends StatelessWidget {
-  const _NotationRow({required this.notation});
+  const _NotationRow({required this.notation, required this.screen});
 
   final Notation notation;
+  final LibraryScreen screen;
 
   @override
   Widget build(BuildContext context) {
+    final canEdit = screen.notationRepository != null &&
+        screen.tagRepository != null &&
+        screen.instrumentRepository != null &&
+        screen.customFieldRepository != null &&
+        screen.fileStorageService != null;
+
     return Semantics(
       label: notation.title,
       child: Dismissible(
@@ -211,9 +277,67 @@ class _NotationRow extends StatelessWidget {
         confirmDismiss: (_) => _confirmDelete(context),
         // Removal from list is driven by the stream; no local state needed.
         onDismissed: (_) {},
-        child: _NotationRowContent(notation: notation),
+        child: canEdit
+            ? GestureDetector(
+                onLongPress: () => _showContextMenu(context),
+                child: _NotationRowContent(notation: notation),
+              )
+            : _NotationRowContent(notation: notation),
       ),
     );
+  }
+
+  Future<void> _showContextMenu(BuildContext context) async {
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+
+    final offset = renderBox.localToGlobal(Offset.zero);
+    final position = RelativeRect.fromLTRB(
+      offset.dx,
+      offset.dy,
+      offset.dx + renderBox.size.width,
+      offset.dy + renderBox.size.height,
+    );
+
+    final choice = await showMenu<String>(
+      context: context,
+      position: position,
+      items: [
+        PopupMenuItem<String>(
+          value: 'edit',
+          child: Row(
+            children: [
+              Icon(
+                Icons.edit_outlined,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const SizedBox(width: 12),
+              const Text('Edit'),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (choice != 'edit') return;
+    if (!context.mounted) return;
+    await _openEdit(context);
+  }
+
+  Future<void> _openEdit(BuildContext context) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => EditNotationScreen(
+          notationId: notation.id,
+          notationRepository: screen.notationRepository!,
+          tagRepository: screen.tagRepository!,
+          instrumentRepository: screen.instrumentRepository!,
+          customFieldRepository: screen.customFieldRepository!,
+          fileStorageService: screen.fileStorageService!,
+        ),
+      ),
+    );
+    // No reload needed — LibraryViewModel observes the notation stream.
   }
 
   Future<bool?> _confirmDelete(BuildContext context) async {
@@ -252,8 +376,8 @@ class _NotationRow extends StatelessWidget {
 
     if (vm.operationError != null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: const Text('Could not delete notation. Please try again.'),
+        const SnackBar(
+          content: Text('Could not delete notation. Please try again.'),
         ),
       );
       vm.clearOperationError();

--- a/lib/features/notation_detail/screens/notation_detail_screen.dart
+++ b/lib/features/notation_detail/screens/notation_detail_screen.dart
@@ -10,20 +10,37 @@
 // action appears for 5 seconds, and the screen navigates back to the library
 // (route '/').
 //
+// Edit interaction: the AppBar "Edit" action launches [EditNotationScreen]
+// via [Navigator.push]. On return the notation detail is reloaded to reflect
+// any changes.
+//
 // Dependencies are injected at the call site:
 //   ChangeNotifierProvider<NotationDetailViewModel>(
 //     create: (_) => NotationDetailViewModel(
 //       notationRepository,
 //       trashRepository,
 //     ),
-//     child: NotationDetailScreen(notationId: id),
+//     child: NotationDetailScreen(
+//       notationId: id,
+//       notationRepository: notationRepository,
+//       tagRepository: tagRepository,
+//       instrumentRepository: instrumentRepository,
+//       customFieldRepository: customFieldRepository,
+//       fileStorageService: fileStorageService,
+//     ),
 //   )
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+import 'package:swaralipi/features/edit/screens/edit_notation_screen.dart';
 import 'package:swaralipi/features/notation_detail/viewmodels/notation_detail_view_model.dart';
 import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,15 +61,46 @@ const EdgeInsets _kContentPadding =
 ///
 /// Reads [NotationDetailViewModel] from the widget tree. Calls
 /// [NotationDetailViewModel.loadNotation] after the first frame.
+///
+/// When the edit dependencies are provided the AppBar shows an Edit action
+/// that launches [EditNotationScreen]. On return the notation is reloaded.
 class NotationDetailScreen extends StatefulWidget {
   /// Creates a [NotationDetailScreen] for the notation with [notationId].
   ///
   /// Parameters:
   /// - [notationId]: UUIDv4 of the notation to display.
-  const NotationDetailScreen({required this.notationId, super.key});
+  /// - [notationRepository]: Passed to [EditNotationScreen] when editing.
+  /// - [tagRepository]: Passed to [EditNotationScreen] when editing.
+  /// - [instrumentRepository]: Passed to [EditNotationScreen] when editing.
+  /// - [customFieldRepository]: Passed to [EditNotationScreen] when editing.
+  /// - [fileStorageService]: Passed to [EditNotationScreen] when editing.
+  const NotationDetailScreen({
+    required this.notationId,
+    this.notationRepository,
+    this.tagRepository,
+    this.instrumentRepository,
+    this.customFieldRepository,
+    this.fileStorageService,
+    super.key,
+  });
 
   /// UUIDv4 of the notation to display.
   final String notationId;
+
+  /// Used by [EditNotationScreen]. When null the Edit action is hidden.
+  final NotationRepository? notationRepository;
+
+  /// Used by [EditNotationScreen] for tag picker.
+  final TagRepository? tagRepository;
+
+  /// Used by [EditNotationScreen] for instrument picker.
+  final InstrumentRepository? instrumentRepository;
+
+  /// Used by [EditNotationScreen] for custom field inputs.
+  final CustomFieldRepository? customFieldRepository;
+
+  /// Used by [EditNotationScreen] to resolve image paths.
+  final FileStorageService? fileStorageService;
 
   @override
   State<NotationDetailScreen> createState() => _NotationDetailScreenState();
@@ -71,11 +119,27 @@ class _NotationDetailScreenState extends State<NotationDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<NotationDetailViewModel>();
+    final canEdit = vm.state is NotationDetailStateSuccess &&
+        widget.notationRepository != null &&
+        widget.tagRepository != null &&
+        widget.instrumentRepository != null &&
+        widget.customFieldRepository != null &&
+        widget.fileStorageService != null;
 
     return Scaffold(
       appBar: AppBar(
         title: _AppBarTitle(state: vm.state),
         actions: [
+          if (canEdit)
+            Semantics(
+              label: 'Edit notation',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                tooltip: 'Edit',
+                onPressed: () => _openEdit(context, vm),
+              ),
+            ),
           if (vm.state is NotationDetailStateSuccess)
             Semantics(
               label: 'Delete notation',
@@ -98,6 +162,27 @@ class _NotationDetailScreenState extends State<NotationDetailScreen> {
           _ErrorView(message: message),
       },
     );
+  }
+
+  Future<void> _openEdit(
+    BuildContext context,
+    NotationDetailViewModel vm,
+  ) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => EditNotationScreen(
+          notationId: widget.notationId,
+          notationRepository: widget.notationRepository!,
+          tagRepository: widget.tagRepository!,
+          instrumentRepository: widget.instrumentRepository!,
+          customFieldRepository: widget.customFieldRepository!,
+          fileStorageService: widget.fileStorageService!,
+        ),
+      ),
+    );
+    if (!context.mounted) return;
+    // Reload so the detail view reflects any saved changes.
+    vm.loadNotation(widget.notationId);
   }
 
   Future<void> _confirmDelete(

--- a/lib/shared/repositories/notation_repository.dart
+++ b/lib/shared/repositories/notation_repository.dart
@@ -101,6 +101,21 @@ abstract interface class NotationRepository {
   /// Parameters:
   /// - [id]: The UUIDv4 primary key of the notation that was played.
   Future<void> updatePlayCount(String id);
+
+  /// Updates the [renderParams] JSON string for a single notation page.
+  ///
+  /// Used by the edit flow to persist non-destructive render-parameter changes
+  /// (filter, crop, rotation) without touching the original image file.
+  ///
+  /// If no page with [pageId] exists the call is silently ignored.
+  ///
+  /// Parameters:
+  /// - [pageId]: The UUIDv4 primary key of the page to update.
+  /// - [renderParamsJson]: Serialised [RenderParams] JSON string.
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/features/capture/viewmodels/metadata_form_view_model_test.dart
+++ b/test/unit/features/capture/viewmodels/metadata_form_view_model_test.dart
@@ -195,6 +195,12 @@ class FakeNotationRepository implements NotationRepository {
 
   @override
   Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
 }
 
 // Slow repo for concurrency test

--- a/test/unit/features/edit/viewmodels/edit_notation_view_model_test.dart
+++ b/test/unit/features/edit/viewmodels/edit_notation_view_model_test.dart
@@ -1,0 +1,734 @@
+// Unit tests for EditNotationViewModel.
+//
+// Covers:
+// - Initial state is EditNotationStateIdle
+// - loadNotation: transitions idle → loading → success with pre-populated state
+// - loadNotation: transitions idle → loading → notFound when no notation exists
+// - loadNotation: transitions idle → loading → error on repository exception
+// - Pre-population: formState title matches loaded notation title
+// - Pre-population: formState artists matches loaded notation artists
+// - Pre-population: formState dateWritten matches loaded notation dateWritten
+// - Pre-population: formState timeSig matches loaded notation timeSig
+// - Pre-population: formState keySig matches loaded notation keySig
+// - Pre-population: formState languages matches loaded notation languages
+// - Pre-population: formState notes matches loaded notation notes
+// - Pre-population: formState selectedTagIds matches loaded notation tags
+// - Pre-population: formState customFieldValues populated from customFieldValues
+// - Pre-population: existingPages built from NotationDetail pages
+// - save: blocked when title empty
+// - save: blocked while already saving
+// - save: calls updateNotation with correct draft
+// - save: transitions to EditNotationSaveDone with notationId on success
+// - save: transitions to EditNotationSaveError on repository failure
+// - clearSaveError: resets saveState to EditNotationSaveIdle
+// - notifyListeners fired on loadNotation state transitions
+// - notifyListeners fired on save state transitions
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/edit/viewmodels/edit_notation_view_model.dart';
+import 'package:swaralipi/shared/models/custom_field_value.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  NotationDetail? notationToReturn;
+  Object? loadError;
+
+  Notation? savedNotation;
+  Notation? updatedNotation;
+  Object? updateError;
+
+  String? lastUpdateId;
+  NotationDraft? lastUpdateDraft;
+  List<SavedPage>? lastSavedPages;
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async {
+    if (loadError != null) throw loadError!;
+    return notationToReturn;
+  }
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async {
+    lastSavedPages = pages;
+    if (savedNotation != null) return savedNotation!;
+    throw UnimplementedError('saveNotation not configured in fake');
+  }
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async {
+    lastUpdateId = id;
+    lastUpdateDraft = draft;
+    if (updateError != null) throw updateError!;
+    if (updatedNotation != null) return updatedNotation!;
+    throw UnimplementedError('updatedNotation not configured in fake');
+  }
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<void> softDelete(String id) async {}
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  final List<(String, String)> pageRenderParamsUpdates = [];
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {
+    pageRenderParamsUpdates.add((pageId, renderParamsJson));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Notation _makeNotation({
+  String id = 'notation-1',
+  String title = 'Raag Bhairav',
+  List<String> artists = const ['Ravi Shankar'],
+  String? dateWritten = '2024-01-15',
+  String? timeSig = '4/4',
+  String? keySig = 'C',
+  List<String> languages = const ['Hindi'],
+  String notes = 'practice notes',
+}) =>
+    Notation(
+      id: id,
+      title: title,
+      artists: artists,
+      dateWritten: dateWritten,
+      timeSig: timeSig,
+      keySig: keySig,
+      languages: languages,
+      notes: notes,
+      playCount: 0,
+      lastPlayedAt: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      deletedAt: null,
+    );
+
+Tag _makeTag({
+  String id = 'tag-1',
+  String name = 'Classical',
+  String colorHex = '#FF0000',
+}) =>
+    Tag(
+      id: id,
+      name: name,
+      colorHex: colorHex,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    );
+
+NotationPage _makePage({
+  String id = 'page-1',
+  String notationId = 'notation-1',
+  int pageOrder = 0,
+  String imagePath = 'notations/notation-1/page_0_original.jpg',
+  String renderParams = '{}',
+  String createdAt = '2024-01-01T00:00:00Z',
+}) =>
+    NotationPage(
+      id: id,
+      notationId: notationId,
+      pageOrder: pageOrder,
+      imagePath: imagePath,
+      renderParams: renderParams,
+      createdAt: createdAt,
+    );
+
+NotationDetail _makeDetail({
+  Notation? notation,
+  List<NotationPage> pages = const [],
+  List<Tag> tags = const [],
+  List<CustomFieldValue> customFieldValues = const [],
+}) =>
+    NotationDetail(
+      notation: notation ?? _makeNotation(),
+      pages: pages,
+      tags: tags,
+      customFieldValues: customFieldValues,
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository repo;
+
+  setUp(() {
+    repo = FakeNotationRepository();
+  });
+
+  EditNotationViewModel makeVm() => EditNotationViewModel(
+        notationRepository: repo,
+      );
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  group('initial state', () {
+    test('state is EditNotationStateIdle', () {
+      final vm = makeVm();
+      expect(vm.state, isA<EditNotationStateIdle>());
+    });
+
+    test('saveState is EditNotationSaveIdle', () {
+      final vm = makeVm();
+      expect(vm.saveState, isA<EditNotationSaveIdle>());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loadNotation
+  // -------------------------------------------------------------------------
+
+  group('loadNotation', () {
+    test('transitions to loading then success', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+
+      final states = <EditNotationState>[];
+      vm.addListener(() => states.add(vm.state));
+
+      await vm.loadNotation('notation-1');
+
+      expect(states.first, isA<EditNotationStateLoading>());
+      expect(states.last, isA<EditNotationStateSuccess>());
+    });
+
+    test('success state contains notationId', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+
+      await vm.loadNotation('notation-1');
+
+      final success = vm.state as EditNotationStateSuccess;
+      expect(success.notationId, equals('notation-1'));
+    });
+
+    test('transitions to notFound when repository returns null', () async {
+      repo.notationToReturn = null;
+      final vm = makeVm();
+
+      await vm.loadNotation('missing-id');
+
+      expect(vm.state, isA<EditNotationStateNotFound>());
+    });
+
+    test('transitions to error when repository throws', () async {
+      repo.loadError = Exception('db error');
+      final vm = makeVm();
+
+      await vm.loadNotation('notation-1');
+
+      expect(vm.state, isA<EditNotationStateError>());
+    });
+
+    test('error state contains message', () async {
+      repo.loadError = Exception('db error');
+      final vm = makeVm();
+
+      await vm.loadNotation('notation-1');
+
+      final error = vm.state as EditNotationStateError;
+      expect(error.message, contains('db error'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-population: formState fields
+  // -------------------------------------------------------------------------
+
+  group('pre-population — formState', () {
+    test('title pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(title: 'Raag Yaman'),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.title, equals('Raag Yaman'));
+    });
+
+    test('artists pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(artists: ['Pt. Ravi Shankar', 'Ustad Ali Khan']),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.artists, equals(['Pt. Ravi Shankar', 'Ustad Ali Khan']));
+    });
+
+    test('dateWritten pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(dateWritten: '2023-06-15'),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.dateWritten, equals('2023-06-15'));
+    });
+
+    test('timeSig pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(timeSig: '6/8'),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.timeSig, equals('6/8'));
+    });
+
+    test('keySig pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(keySig: 'D minor'),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.keySig, equals('D minor'));
+    });
+
+    test('languages pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(languages: ['Hindi', 'Bengali']),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.languages, equals(['Hindi', 'Bengali']));
+    });
+
+    test('notes pre-populated from notation', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(notes: 'practice early morning'),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.notes, equals('practice early morning'));
+    });
+
+    test('selectedTagIds pre-populated from detail tags', () async {
+      repo.notationToReturn = _makeDetail(
+        tags: [
+          _makeTag(id: 'tag-1'),
+          _makeTag(id: 'tag-2', name: 'Folk'),
+        ],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.selectedTagIds, containsAll(['tag-1', 'tag-2']));
+    });
+
+    test(
+        'customFieldValues pre-populated from text custom field values',
+        () async {
+      repo.notationToReturn = _makeDetail(
+        customFieldValues: [
+          const CustomFieldValue(
+            notationId: 'notation-1',
+            definitionId: 'cf-1',
+            valueText: 'some text',
+          ),
+        ],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.formState.customFieldValues, contains('cf-1'));
+      expect(
+        vm.formState.customFieldValues['cf-1']?.textValue,
+        equals('some text'),
+      );
+    });
+
+    test('customFieldValues pre-populated from number custom field values',
+        () async {
+      repo.notationToReturn = _makeDetail(
+        customFieldValues: [
+          const CustomFieldValue(
+            notationId: 'notation-1',
+            definitionId: 'cf-2',
+            valueNumber: 42.5,
+          ),
+        ],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(
+        vm.formState.customFieldValues['cf-2']?.numberValue,
+        equals(42.5),
+      );
+    });
+
+    test('customFieldValues pre-populated from boolean custom field values',
+        () async {
+      repo.notationToReturn = _makeDetail(
+        customFieldValues: [
+          const CustomFieldValue(
+            notationId: 'notation-1',
+            definitionId: 'cf-3',
+            valueBoolean: true,
+          ),
+        ],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(
+        vm.formState.customFieldValues['cf-3']?.booleanValue,
+        isTrue,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-population: existingPages
+  // -------------------------------------------------------------------------
+
+  group('pre-population — existingPages', () {
+    test('existingPages populated from detail pages after load', () async {
+      repo.notationToReturn = _makeDetail(
+        pages: [
+          _makePage(id: 'p1', pageOrder: 0),
+          _makePage(id: 'p2', pageOrder: 1),
+        ],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.existingPages, hasLength(2));
+      expect(vm.existingPages[0].id, equals('p1'));
+      expect(vm.existingPages[1].id, equals('p2'));
+    });
+
+    test('existingPages empty when notation has no pages', () async {
+      repo.notationToReturn = _makeDetail(pages: []);
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      expect(vm.existingPages, isEmpty);
+    });
+
+    test('existingPages empty before load', () {
+      final vm = makeVm();
+      expect(vm.existingPages, isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Form field setters
+  // -------------------------------------------------------------------------
+
+  group('form field setters', () {
+    test('setTitle updates formState and notifies listeners', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      vm.setTitle('New Title');
+
+      expect(vm.formState.title, equals('New Title'));
+      expect(notified, isTrue);
+    });
+
+    test('addArtist appends artist to list', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(artists: ['A']),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.addArtist('B');
+      expect(vm.formState.artists, equals(['A', 'B']));
+    });
+
+    test('removeArtist removes artist at index', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(artists: ['A', 'B', 'C']),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.removeArtist(1);
+      expect(vm.formState.artists, equals(['A', 'C']));
+    });
+
+    test('toggleLanguage adds missing language', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.toggleLanguage('Bengali');
+      expect(vm.formState.languages, contains('Bengali'));
+    });
+
+    test('toggleLanguage removes existing language', () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(languages: ['Hindi']),
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.toggleLanguage('Hindi');
+      expect(vm.formState.languages, isNot(contains('Hindi')));
+    });
+
+    test('toggleTag adds missing tag id', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.toggleTag('tag-99');
+      expect(vm.formState.selectedTagIds, contains('tag-99'));
+    });
+
+    test('toggleTag removes existing tag id', () async {
+      repo.notationToReturn = _makeDetail(
+        tags: [_makeTag(id: 'tag-1')],
+      );
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.toggleTag('tag-1');
+      expect(vm.formState.selectedTagIds, isNot(contains('tag-1')));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isTitleValid
+  // -------------------------------------------------------------------------
+
+  group('isTitleValid', () {
+    test('returns false when title is empty', () async {
+      repo.notationToReturn =
+          _makeDetail(notation: _makeNotation(title: ''));
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+      expect(vm.isTitleValid, isFalse);
+    });
+
+    test('returns false when title is whitespace only', () async {
+      repo.notationToReturn =
+          _makeDetail(notation: _makeNotation(title: '   '));
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+      expect(vm.isTitleValid, isFalse);
+    });
+
+    test('returns true when title is non-empty', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+      expect(vm.isTitleValid, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // save
+  // -------------------------------------------------------------------------
+
+  group('save', () {
+    test('no-op when title is empty', () async {
+      repo.notationToReturn =
+          _makeDetail(notation: _makeNotation(title: ''));
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      await vm.save(updatedPages: []);
+
+      expect(vm.saveState, isA<EditNotationSaveIdle>());
+    });
+
+    test('no-op when already saving', () async {
+      repo.notationToReturn = _makeDetail();
+      final updatedNotation = _makeNotation();
+      repo.updatedNotation = updatedNotation;
+
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      // Kick off two saves concurrently; the second must be a no-op.
+      final firstSave = vm.save(updatedPages: []);
+      final secondSave = vm.save(updatedPages: []);
+      await Future.wait([firstSave, secondSave]);
+
+      // Only one updateNotation call.
+      expect(repo.lastUpdateId, equals('notation-1'));
+    });
+
+    test(
+        'calls updateNotation with correct id and draft on success',
+        () async {
+      repo.notationToReturn = _makeDetail(
+        notation: _makeNotation(title: 'Raag Bhairav'),
+        tags: [_makeTag(id: 'tag-1')],
+      );
+      repo.updatedNotation = _makeNotation();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      await vm.save(updatedPages: []);
+
+      expect(repo.lastUpdateId, equals('notation-1'));
+      expect(repo.lastUpdateDraft?.title, equals('Raag Bhairav'));
+      expect(repo.lastUpdateDraft?.tagIds, equals(['tag-1']));
+    });
+
+    test('transitions to saving then done on success', () async {
+      repo.notationToReturn = _makeDetail();
+      repo.updatedNotation = _makeNotation();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      final states = <EditNotationSaveState>[];
+      vm.addListener(() => states.add(vm.saveState));
+
+      await vm.save(updatedPages: []);
+
+      expect(states.first, isA<EditNotationSaving>());
+      expect(states.last, isA<EditNotationSaveDone>());
+    });
+
+    test('saveDone contains notationId', () async {
+      repo.notationToReturn = _makeDetail();
+      repo.updatedNotation = _makeNotation(id: 'notation-1');
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      await vm.save(updatedPages: []);
+
+      final done = vm.saveState as EditNotationSaveDone;
+      expect(done.notationId, equals('notation-1'));
+    });
+
+    test('transitions to saveError on repository failure', () async {
+      repo.notationToReturn = _makeDetail();
+      repo.updateError = Exception('update failed');
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      await vm.save(updatedPages: []);
+
+      expect(vm.saveState, isA<EditNotationSaveError>());
+    });
+
+    test('saveError contains message on repository failure', () async {
+      repo.notationToReturn = _makeDetail();
+      repo.updateError = Exception('update failed');
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      await vm.save(updatedPages: []);
+
+      final error = vm.saveState as EditNotationSaveError;
+      expect(error.message, contains('update failed'));
+    });
+
+    test(
+        'passes updatedPages pages as SavedPage list to updateNotation draft',
+        () async {
+      repo.notationToReturn = _makeDetail(
+        pages: [_makePage(id: 'p1', imagePath: 'notations/n1/page_0_original.jpg')],
+      );
+      repo.updatedNotation = _makeNotation();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      final updatedPage = _makePage(
+        id: 'p1',
+        imagePath: 'notations/n1/page_0_original.jpg',
+        renderParams: '{"filter":"grayscale","rotation_degrees":0}',
+      );
+
+      await vm.save(updatedPages: [updatedPage]);
+
+      // updateNotation was called (not saveNotation)
+      expect(repo.lastUpdateId, isNotNull);
+      expect(repo.lastSavedPages, isNull);
+    });
+
+    test('persists render params for each updated page', () async {
+      repo.notationToReturn = _makeDetail(
+        pages: [
+          _makePage(id: 'p1'),
+          _makePage(id: 'p2', pageOrder: 1),
+        ],
+      );
+      repo.updatedNotation = _makeNotation();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      final updatedPages = [
+        _makePage(id: 'p1', renderParams: '{"filter":"grayscale"}'),
+        _makePage(id: 'p2', pageOrder: 1, renderParams: '{"rotation_degrees":90}'),
+      ];
+
+      await vm.save(updatedPages: updatedPages);
+
+      expect(repo.pageRenderParamsUpdates, hasLength(2));
+      expect(repo.pageRenderParamsUpdates[0].$1, equals('p1'));
+      expect(repo.pageRenderParamsUpdates[0].$2, equals('{"filter":"grayscale"}'));
+      expect(repo.pageRenderParamsUpdates[1].$1, equals('p2'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // clearSaveError
+  // -------------------------------------------------------------------------
+
+  group('clearSaveError', () {
+    test('resets saveState to idle from error', () async {
+      repo.notationToReturn = _makeDetail();
+      repo.updateError = Exception('fail');
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+      await vm.save(updatedPages: []);
+
+      expect(vm.saveState, isA<EditNotationSaveError>());
+      vm.clearSaveError();
+      expect(vm.saveState, isA<EditNotationSaveIdle>());
+    });
+
+    test('no-op when not in error state', () async {
+      repo.notationToReturn = _makeDetail();
+      final vm = makeVm();
+      await vm.loadNotation('notation-1');
+
+      vm.clearSaveError(); // should not throw
+      expect(vm.saveState, isA<EditNotationSaveIdle>());
+    });
+  });
+}

--- a/test/unit/features/library/viewmodels/library_view_model_test.dart
+++ b/test/unit/features/library/viewmodels/library_view_model_test.dart
@@ -64,6 +64,12 @@ class FakeNotationRepository implements NotationRepository {
   @override
   Future<void> updatePlayCount(String id) async {}
 
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
+
   void close() => _controller.close();
 }
 

--- a/test/unit/features/notation_detail/viewmodels/notation_detail_view_model_test.dart
+++ b/test/unit/features/notation_detail/viewmodels/notation_detail_view_model_test.dart
@@ -67,6 +67,12 @@ class FakeNotationRepository implements NotationRepository {
 
   @override
   Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
 }
 
 class FakeTrashRepository implements TrashRepository {

--- a/test/widget/features/capture/metadata_form_screen_test.dart
+++ b/test/widget/features/capture/metadata_form_screen_test.dart
@@ -140,6 +140,12 @@ class _FakeNotationRepository implements NotationRepository {
   Future<void> softDelete(String id) async {}
   @override
   Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
 }
 
 class _FakeFileStorageService extends FileStorageService {


### PR DESCRIPTION
## Linked Issue
Closes #89

## Summary
- Adds `updatePageRenderParams` to `NotationRepository` interface and `NotationRepositoryImpl` to persist per-page render-param changes without re-writing image files
- Implements `EditNotationViewModel` (sealed load/save states, pre-population from `NotationDetail`, save via `updateNotation` + `updatePageRenderParams`)
- Adds `EditNotationScreen` (orchestrates `PageEditorScreen` → `EditMetadataFormScreen`) and `EditMetadataFormScreen` (pre-populated metadata form delegating save to `EditNotationViewModel`)
- Adds edit entry points: Edit icon in `NotationDetailScreen` AppBar and long-press popup menu in `LibraryScreen` rows; both launch `EditNotationScreen` with injected dependencies

## Type of Change
- [x] feat — new capability

## Commit Convention
`feat(edit): implement edit notation flow — re-enter metadata form and page editor (#89)`

## Test Plan
- [x] Unit tests written: `test/unit/features/edit/viewmodels/edit_notation_view_model_test.dart` — 42 tests covering all load/save states, pre-population of all fields, form setters, render-param persistence
- [x] `flutter test ./test/unit ./test/widget` passes — 973 tests, 0 failures
- [x] Coverage ≥ 80% on new business logic (`EditNotationViewModel`)
- [x] `flutter analyze` — 0 errors, 0 warnings on touched files (4 pre-existing severity-3 hints in untouched files)
- [x] `dart format` applied — 0 changes

## Screenshots / Recordings
UI entry points are standard Material 3 `IconButton` (edit icon in AppBar) and `PopupMenuItem` (long-press row menu). No golden tests required for this task.

## Checklist
- [x] No `print` statements (use `dart:developer` `log`)
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] Generated files committed (`.g.dart`)
- [x] No hardcoded secrets