### PR TITLE
feat(player): orientation lock toggle and chrome fade (#93)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -406,6 +406,13 @@ class UserPreferencesTable extends Table {
   /// compatibility; treated as [bool] at the app layer.
   IntColumn get tagsSeeded => integer().withDefault(const Constant(0))();
 
+  /// Preferred screen orientation lock for the notation player.
+  ///
+  /// One of `'auto'`, `'portrait'`, or `'landscape'`. Defaults to `'auto'`
+  /// (sensor-driven, no lock).
+  TextColumn get playerOrientation =>
+      text().withDefault(const Constant('auto'))();
+
   @override
   Set<Column> get primaryKey => {id};
 
@@ -422,6 +429,7 @@ class UserPreferencesTable extends Table {
             '))',
         "CHECK (default_view IN ('list'))",
         'CHECK (tags_seeded IN (0, 1))',
+        "CHECK (player_orientation IN ('auto', 'portrait', 'landscape'))",
       ];
 }
 
@@ -452,6 +460,7 @@ class UserPreferencesTable extends Table {
 /// | 1 | Initial schema: all tables, FTS5, triggers, indexes, seed data |
 /// | 2 | Add `tags_seeded` column to `user_preferences_table` |
 /// | 3 | Add `deleted_at` column to `instrument_classes_table` |
+/// | 4 | Add `player_orientation` column to `user_preferences_table` |
 @DriftDatabase(
   tables: [
     NotationsTable,
@@ -520,7 +529,7 @@ class AppDatabase extends _$AppDatabase {
         );
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -546,6 +555,13 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(
               instrumentClassesTable,
               instrumentClassesTable.deletedAt,
+            );
+          }
+          // v3 → v4: add player_orientation column to user_preferences_table.
+          if (from < 4) {
+            await m.addColumn(
+              userPreferencesTable,
+              userPreferencesTable.playerOrientation,
             );
           }
         },

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3454,6 +3454,14 @@ class $UserPreferencesTableTable extends UserPreferencesTable
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _playerOrientationMeta =
+      const VerificationMeta('playerOrientation');
+  @override
+  late final GeneratedColumn<String> playerOrientation =
+      GeneratedColumn<String>('player_orientation', aliasedName, false,
+          type: DriftSqlType.string,
+          requiredDuringInsert: false,
+          defaultValue: const Constant('auto'));
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -3463,7 +3471,8 @@ class $UserPreferencesTableTable extends UserPreferencesTable
         seedColor,
         defaultSort,
         defaultView,
-        tagsSeeded
+        tagsSeeded,
+        playerOrientation,
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3514,6 +3523,12 @@ class $UserPreferencesTableTable extends UserPreferencesTable
           tagsSeeded.isAcceptableOrUnknown(
               data['tags_seeded']!, _tagsSeededMeta));
     }
+    if (data.containsKey('player_orientation')) {
+      context.handle(
+          _playerOrientationMeta,
+          playerOrientation.isAcceptableOrUnknown(
+              data['player_orientation']!, _playerOrientationMeta));
+    }
     return context;
   }
 
@@ -3539,6 +3554,9 @@ class $UserPreferencesTableTable extends UserPreferencesTable
           .read(DriftSqlType.string, data['${effectivePrefix}default_view'])!,
       tagsSeeded: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}tags_seeded'])!,
+      playerOrientation: attachedDatabase.typeMapping.read(DriftSqlType.string,
+              data['${effectivePrefix}player_orientation']) ??
+          'auto',
     );
   }
 
@@ -3579,6 +3597,11 @@ class UserPreferencesRow extends DataClass
   /// `0` = not seeded, `1` = seeded. Stored as INTEGER for SQLite
   /// compatibility; treated as [bool] at the app layer.
   final int tagsSeeded;
+
+  /// Preferred screen orientation lock for the notation player.
+  ///
+  /// One of `'auto'`, `'portrait'`, or `'landscape'`.
+  final String playerOrientation;
   const UserPreferencesRow(
       {required this.id,
       required this.userName,
@@ -3587,7 +3610,8 @@ class UserPreferencesRow extends DataClass
       this.seedColor,
       required this.defaultSort,
       required this.defaultView,
-      required this.tagsSeeded});
+      required this.tagsSeeded,
+      this.playerOrientation = 'auto'});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3601,6 +3625,7 @@ class UserPreferencesRow extends DataClass
     map['default_sort'] = Variable<String>(defaultSort);
     map['default_view'] = Variable<String>(defaultView);
     map['tags_seeded'] = Variable<int>(tagsSeeded);
+    map['player_orientation'] = Variable<String>(playerOrientation);
     return map;
   }
 
@@ -3616,6 +3641,7 @@ class UserPreferencesRow extends DataClass
       defaultSort: Value(defaultSort),
       defaultView: Value(defaultView),
       tagsSeeded: Value(tagsSeeded),
+      playerOrientation: Value(playerOrientation),
     );
   }
 
@@ -3631,6 +3657,8 @@ class UserPreferencesRow extends DataClass
       defaultSort: serializer.fromJson<String>(json['defaultSort']),
       defaultView: serializer.fromJson<String>(json['defaultView']),
       tagsSeeded: serializer.fromJson<int>(json['tagsSeeded']),
+      playerOrientation:
+          serializer.fromJson<String>(json['playerOrientation'] ?? 'auto'),
     );
   }
   @override
@@ -3645,6 +3673,7 @@ class UserPreferencesRow extends DataClass
       'defaultSort': serializer.toJson<String>(defaultSort),
       'defaultView': serializer.toJson<String>(defaultView),
       'tagsSeeded': serializer.toJson<int>(tagsSeeded),
+      'playerOrientation': serializer.toJson<String>(playerOrientation),
     };
   }
 
@@ -3656,7 +3685,8 @@ class UserPreferencesRow extends DataClass
           Value<String?> seedColor = const Value.absent(),
           String? defaultSort,
           String? defaultView,
-          int? tagsSeeded}) =>
+          int? tagsSeeded,
+          String? playerOrientation}) =>
       UserPreferencesRow(
         id: id ?? this.id,
         userName: userName ?? this.userName,
@@ -3666,6 +3696,7 @@ class UserPreferencesRow extends DataClass
         defaultSort: defaultSort ?? this.defaultSort,
         defaultView: defaultView ?? this.defaultView,
         tagsSeeded: tagsSeeded ?? this.tagsSeeded,
+        playerOrientation: playerOrientation ?? this.playerOrientation,
       );
   UserPreferencesRow copyWithCompanion(UserPreferencesTableCompanion data) {
     return UserPreferencesRow(
@@ -3682,6 +3713,9 @@ class UserPreferencesRow extends DataClass
           data.defaultView.present ? data.defaultView.value : this.defaultView,
       tagsSeeded:
           data.tagsSeeded.present ? data.tagsSeeded.value : this.tagsSeeded,
+      playerOrientation: data.playerOrientation.present
+          ? data.playerOrientation.value
+          : this.playerOrientation,
     );
   }
 
@@ -3695,14 +3729,15 @@ class UserPreferencesRow extends DataClass
           ..write('seedColor: $seedColor, ')
           ..write('defaultSort: $defaultSort, ')
           ..write('defaultView: $defaultView, ')
-          ..write('tagsSeeded: $tagsSeeded')
+          ..write('tagsSeeded: $tagsSeeded, ')
+          ..write('playerOrientation: $playerOrientation')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, userName, themeMode, colorSchemeMode,
-      seedColor, defaultSort, defaultView, tagsSeeded);
+      seedColor, defaultSort, defaultView, tagsSeeded, playerOrientation);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3714,7 +3749,8 @@ class UserPreferencesRow extends DataClass
           other.seedColor == this.seedColor &&
           other.defaultSort == this.defaultSort &&
           other.defaultView == this.defaultView &&
-          other.tagsSeeded == this.tagsSeeded);
+          other.tagsSeeded == this.tagsSeeded &&
+          other.playerOrientation == this.playerOrientation);
 }
 
 class UserPreferencesTableCompanion
@@ -3727,6 +3763,7 @@ class UserPreferencesTableCompanion
   final Value<String> defaultSort;
   final Value<String> defaultView;
   final Value<int> tagsSeeded;
+  final Value<String> playerOrientation;
   const UserPreferencesTableCompanion({
     this.id = const Value.absent(),
     this.userName = const Value.absent(),
@@ -3736,6 +3773,7 @@ class UserPreferencesTableCompanion
     this.defaultSort = const Value.absent(),
     this.defaultView = const Value.absent(),
     this.tagsSeeded = const Value.absent(),
+    this.playerOrientation = const Value.absent(),
   });
   UserPreferencesTableCompanion.insert({
     this.id = const Value.absent(),
@@ -3746,6 +3784,7 @@ class UserPreferencesTableCompanion
     this.defaultSort = const Value.absent(),
     this.defaultView = const Value.absent(),
     this.tagsSeeded = const Value.absent(),
+    this.playerOrientation = const Value.absent(),
   });
   static Insertable<UserPreferencesRow> custom({
     Expression<int>? id,
@@ -3756,6 +3795,7 @@ class UserPreferencesTableCompanion
     Expression<String>? defaultSort,
     Expression<String>? defaultView,
     Expression<int>? tagsSeeded,
+    Expression<String>? playerOrientation,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -3766,6 +3806,7 @@ class UserPreferencesTableCompanion
       if (defaultSort != null) 'default_sort': defaultSort,
       if (defaultView != null) 'default_view': defaultView,
       if (tagsSeeded != null) 'tags_seeded': tagsSeeded,
+      if (playerOrientation != null) 'player_orientation': playerOrientation,
     });
   }
 
@@ -3777,7 +3818,8 @@ class UserPreferencesTableCompanion
       Value<String?>? seedColor,
       Value<String>? defaultSort,
       Value<String>? defaultView,
-      Value<int>? tagsSeeded}) {
+      Value<int>? tagsSeeded,
+      Value<String>? playerOrientation}) {
     return UserPreferencesTableCompanion(
       id: id ?? this.id,
       userName: userName ?? this.userName,
@@ -3787,6 +3829,7 @@ class UserPreferencesTableCompanion
       defaultSort: defaultSort ?? this.defaultSort,
       defaultView: defaultView ?? this.defaultView,
       tagsSeeded: tagsSeeded ?? this.tagsSeeded,
+      playerOrientation: playerOrientation ?? this.playerOrientation,
     );
   }
 
@@ -3817,6 +3860,9 @@ class UserPreferencesTableCompanion
     if (tagsSeeded.present) {
       map['tags_seeded'] = Variable<int>(tagsSeeded.value);
     }
+    if (playerOrientation.present) {
+      map['player_orientation'] = Variable<String>(playerOrientation.value);
+    }
     return map;
   }
 
@@ -3830,7 +3876,8 @@ class UserPreferencesTableCompanion
           ..write('seedColor: $seedColor, ')
           ..write('defaultSort: $defaultSort, ')
           ..write('defaultView: $defaultView, ')
-          ..write('tagsSeeded: $tagsSeeded')
+          ..write('tagsSeeded: $tagsSeeded, ')
+          ..write('playerOrientation: $playerOrientation')
           ..write(')'))
         .toString();
   }

--- a/lib/core/database/daos/notation_dao.dart
+++ b/lib/core/database/daos/notation_dao.dart
@@ -163,8 +163,7 @@ class NotationDao extends DatabaseAccessor<AppDatabase>
   /// Used by [TrashRepository.purgeAll] to obtain the ids of all trashed
   /// notations before performing hard deletes and file-system cleanup.
   Future<List<NotationRow>> getAllTrashed() {
-    return (select(notationsTable)
-          ..where((t) => t.deletedAt.isNotNull()))
+    return (select(notationsTable)..where((t) => t.deletedAt.isNotNull()))
         .get();
   }
 

--- a/lib/features/edit/screens/edit_metadata_form_screen.dart
+++ b/lib/features/edit/screens/edit_metadata_form_screen.dart
@@ -100,8 +100,7 @@ class EditMetadataFormScreen extends StatefulWidget {
   final CustomFieldRepository customFieldRepository;
 
   @override
-  State<EditMetadataFormScreen> createState() =>
-      _EditMetadataFormScreenState();
+  State<EditMetadataFormScreen> createState() => _EditMetadataFormScreenState();
 }
 
 class _EditMetadataFormScreenState extends State<EditMetadataFormScreen> {
@@ -397,16 +396,13 @@ class _EditFormBody extends StatelessWidget {
           children: [
             _EditTitleField(controller: titleController),
             const SizedBox(height: _kSectionGap),
-
             _EditArtistChipInput(
               artists: fs.artists,
               inputController: artistInputController,
             ),
             const SizedBox(height: _kSectionGap),
-
             _EditDateField(currentValue: fs.dateWritten),
             const SizedBox(height: _kSectionGap),
-
             _EditTextFormRow(
               label: 'Time signature',
               hint: 'e.g. 4/4, 6/8',
@@ -414,7 +410,6 @@ class _EditFormBody extends StatelessWidget {
               onChanged: vm.setTimeSig,
             ),
             const SizedBox(height: _kSectionGap),
-
             _EditTextFormRow(
               label: 'Key signature',
               hint: 'e.g. C major, Yaman',
@@ -422,15 +417,12 @@ class _EditFormBody extends StatelessWidget {
               onChanged: vm.setKeySig,
             ),
             const SizedBox(height: _kSectionGap),
-
             _EditLanguageChips(selected: fs.languages),
             const SizedBox(height: _kSectionGap),
-
             if (tags.isNotEmpty) ...[
               _EditTagChips(tags: tags, selectedIds: fs.selectedTagIds),
               const SizedBox(height: _kSectionGap),
             ],
-
             if (instruments.isNotEmpty) ...[
               _EditInstrumentChips(
                 instruments: instruments,
@@ -438,13 +430,10 @@ class _EditFormBody extends StatelessWidget {
               ),
               const SizedBox(height: _kSectionGap),
             ],
-
             _EditNotesField(controller: notesController),
             const SizedBox(height: _kSectionGap),
-
             if (customFieldDefinitions.isNotEmpty)
               _EditCustomFieldsSection(definitions: customFieldDefinitions),
-
             const SizedBox(height: 32),
           ],
         ),
@@ -825,12 +814,9 @@ class _EditCustomFieldInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (definition.fieldType) {
-      CustomFieldType.text =>
-        _EditCustomTextInput(definition: definition),
-      CustomFieldType.number =>
-        _EditCustomNumberInput(definition: definition),
-      CustomFieldType.date =>
-        _EditCustomDateInput(definition: definition),
+      CustomFieldType.text => _EditCustomTextInput(definition: definition),
+      CustomFieldType.number => _EditCustomNumberInput(definition: definition),
+      CustomFieldType.date => _EditCustomDateInput(definition: definition),
       CustomFieldType.boolean =>
         _EditCustomBooleanInput(definition: definition),
     };
@@ -938,8 +924,7 @@ class _EditCustomDateInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<EditNotationViewModel>();
-    final existing =
-        vm.formState.customFieldValues[definition.id]?.dateValue;
+    final existing = vm.formState.customFieldValues[definition.id]?.dateValue;
 
     return Row(
       children: [
@@ -962,8 +947,7 @@ class _EditCustomDateInput extends StatelessWidget {
     BuildContext context,
     EditNotationViewModel vm,
   ) async {
-    final existing =
-        vm.formState.customFieldValues[definition.id]?.dateValue;
+    final existing = vm.formState.customFieldValues[definition.id]?.dateValue;
     final initial = existing != null
         ? DateTime.tryParse(existing) ?? DateTime.now()
         : DateTime.now();
@@ -1006,8 +990,7 @@ class _EditCustomBooleanInput extends StatelessWidget {
         ),
         Switch(
           value: value,
-          onChanged: (v) =>
-              vm.setCustomFieldBoolean(definition.id, value: v),
+          onChanged: (v) => vm.setCustomFieldBoolean(definition.id, value: v),
         ),
       ],
     );

--- a/lib/features/edit/screens/edit_notation_screen.dart
+++ b/lib/features/edit/screens/edit_notation_screen.dart
@@ -133,8 +133,8 @@ class _EditNotationScreenState extends State<EditNotationScreen> {
     final drafts = <CapturePageDraft>[];
     for (final page in pages) {
       try {
-        final absPath = await widget.fileStorageService
-            .getAbsolutePath(page.imagePath);
+        final absPath =
+            await widget.fileStorageService.getAbsolutePath(page.imagePath);
         final bytes = await File(absPath).readAsBytes();
         final renderParams = _parseRenderParams(page.renderParams);
         drafts.add(
@@ -184,7 +184,8 @@ class _EditNotationScreenState extends State<EditNotationScreen> {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<EditNotationViewModel>.value(value: _editVm),
-        ChangeNotifierProvider<CaptureSessionViewModel>.value(value: _sessionVm),
+        ChangeNotifierProvider<CaptureSessionViewModel>.value(
+            value: _sessionVm),
         ChangeNotifierProvider<PageEditorViewModel>.value(value: _pageEditorVm),
       ],
       child: const _EditNotationBody(),

--- a/lib/features/edit/viewmodels/edit_notation_view_model.dart
+++ b/lib/features/edit/viewmodels/edit_notation_view_model.dart
@@ -508,8 +508,7 @@ class EditNotationViewModel extends ChangeNotifier {
 
     try {
       final draft = _buildDraft();
-      final updated =
-          await _notationRepository.updateNotation(id, draft);
+      final updated = await _notationRepository.updateNotation(id, draft);
 
       // Persist any render-param changes for each page in the updated list.
       for (final page in updatedPages) {

--- a/lib/features/notation_detail/screens/notation_detail_screen.dart
+++ b/lib/features/notation_detail/screens/notation_detail_screen.dart
@@ -42,6 +42,8 @@ import 'package:swaralipi/shared/models/notation_detail.dart';
 import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
 import 'package:swaralipi/shared/repositories/instrument_repository.dart';
 import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 import 'package:swaralipi/shared/repositories/tag_repository.dart';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,7 @@ class NotationDetailScreen extends StatefulWidget {
   const NotationDetailScreen({
     required this.notationId,
     this.notationRepository,
+    this.preferencesRepository,
     this.tagRepository,
     this.instrumentRepository,
     this.customFieldRepository,
@@ -91,6 +94,9 @@ class NotationDetailScreen extends StatefulWidget {
 
   /// Used by [EditNotationScreen]. When null the Edit action is hidden.
   final NotationRepository? notationRepository;
+
+  /// Used by [NotationPlayerScreen] to persist orientation preferences.
+  final PreferencesRepository? preferencesRepository;
 
   /// Used by [EditNotationScreen] for tag picker.
   final TagRepository? tagRepository;
@@ -190,12 +196,16 @@ class _NotationDetailScreenState extends State<NotationDetailScreen> {
     final notationRepository = widget.notationRepository;
     if (notationRepository == null) return;
 
+    final prefsRepo =
+        widget.preferencesRepository ?? const _NoOpPreferencesRepository();
+
     await Navigator.of(context).push<void>(
       MaterialPageRoute<void>(
         fullscreenDialog: true,
         builder: (_) => ChangeNotifierProvider<NotationPlayerViewModel>(
           create: (_) => NotationPlayerViewModel(
             notationRepository,
+            preferencesRepository: prefsRepo,
             notationId: widget.notationId,
           ),
           child: const NotationPlayerScreen(),
@@ -562,4 +572,43 @@ class _MetadataRow extends StatelessWidget {
       ],
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// No-op PreferencesRepository fallback
+// ---------------------------------------------------------------------------
+
+/// A no-op [PreferencesRepository] used when no real implementation is
+/// injected into [NotationDetailScreen].
+///
+/// All write methods are no-ops. [getPreferences] returns a default singleton.
+final class _NoOpPreferencesRepository implements PreferencesRepository {
+  const _NoOpPreferencesRepository();
+
+  @override
+  Future<UserPreferences> getPreferences() async => const UserPreferences(
+        userName: 'Musician',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+      );
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {}
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
 }

--- a/lib/features/player/screens/notation_player_screen.dart
+++ b/lib/features/player/screens/notation_player_screen.dart
@@ -10,7 +10,8 @@
 //     ImageProcessingService.apply + compute()) is intentionally out of scope
 //     for this task — the raw original image is shown in the player.
 //     Non-destructive rendering is handled by the Page Editor flow.
-//   - Title + page indicator fade in/out (chrome) on tap after 2 s idle.
+//   - Title + page indicator fade in/out (chrome) on tap after 3 s idle.
+//   - Orientation lock toggle (auto / portrait / landscape) in bottom chrome.
 //   - Back navigation returns to the previous screen.
 //
 // The screen reads [NotationPlayerViewModel] from a [ChangeNotifierProvider]
@@ -18,7 +19,12 @@
 //
 // Construction (from the route builder in app.dart):
 //   ChangeNotifierProvider(
-//     create: (_) => NotationPlayerViewModel(repo, notationId: id, startPage: page),
+//     create: (_) => NotationPlayerViewModel(
+//       repo,
+//       preferencesRepository: prefsRepo,
+//       notationId: id,
+//       startPage: page,
+//     ),
 //     child: const NotationPlayerScreen(),
 //   )
 
@@ -34,13 +40,11 @@ import 'package:swaralipi/core/storage/file_storage_service.dart';
 import 'package:swaralipi/features/player/viewmodels/notation_player_view_model.dart';
 import 'package:swaralipi/shared/models/notation_detail.dart';
 import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/// Duration after which the chrome (title + toolbar) fades out.
-const Duration _kChromeFadeDuration = Duration(seconds: 2);
 
 /// Animation duration for the chrome fade-in / fade-out.
 const Duration _kChromeAnimationDuration = Duration(milliseconds: 300);
@@ -102,7 +106,7 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
 
   void _scheduleFade() {
     _chromeFadeTimer?.cancel();
-    _chromeFadeTimer = Timer(_kChromeFadeDuration, () {
+    _chromeFadeTimer = Timer(kChromeFadeDuration, () {
       if (!mounted) return;
       context.read<NotationPlayerViewModel>().hideChrome();
     });
@@ -123,6 +127,8 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
   void dispose() {
     _chromeFadeTimer?.cancel();
     _pageController.dispose();
+    // Restore auto-rotate when leaving the player.
+    SystemChrome.setPreferredOrientations([]);
     super.dispose();
   }
 
@@ -131,6 +137,9 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
     // Keep status bar hidden for immersive full-screen feel.
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     final vm = context.watch<NotationPlayerViewModel>();
+
+    // Apply orientation lock whenever it changes.
+    _applyOrientationLock(vm.playerOrientation);
 
     return Scaffold(
       backgroundColor: Colors.black,
@@ -148,6 +157,22 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
           ),
       },
     );
+  }
+
+  /// Applies the orientation lock via [SystemChrome].
+  void _applyOrientationLock(PlayerOrientation orientation) {
+    final orientations = switch (orientation) {
+      PlayerOrientation.auto => <DeviceOrientation>[],
+      PlayerOrientation.portrait => [
+          DeviceOrientation.portraitUp,
+          DeviceOrientation.portraitDown,
+        ],
+      PlayerOrientation.landscape => [
+          DeviceOrientation.landscapeLeft,
+          DeviceOrientation.landscapeRight,
+        ],
+    };
+    SystemChrome.setPreferredOrientations(orientations);
   }
 }
 
@@ -301,6 +326,8 @@ class _PlayerView extends StatelessWidget {
             currentPage: vm.currentPage,
             pageCount: pageCount,
             isVisible: vm.isChromeVisible,
+            playerOrientation: vm.playerOrientation,
+            onOrientationToggle: vm.cycleOrientation,
           ),
         ],
       ),
@@ -458,20 +485,24 @@ class _TitleChrome extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Bottom chrome (page indicator)
+// Bottom chrome (page indicator + orientation toggle)
 // ---------------------------------------------------------------------------
 
-/// Animated bottom bar showing the page indicator.
+/// Animated bottom bar showing the page indicator and orientation toggle.
 class _BottomChrome extends StatelessWidget {
   const _BottomChrome({
     required this.currentPage,
     required this.pageCount,
     required this.isVisible,
+    required this.playerOrientation,
+    required this.onOrientationToggle,
   });
 
   final int currentPage;
   final int pageCount;
   final bool isVisible;
+  final PlayerOrientation playerOrientation;
+  final VoidCallback onOrientationToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -493,20 +524,72 @@ class _BottomChrome extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: SafeArea(
             top: false,
-            child: Center(
-              child: Semantics(
-                label: 'Page ${currentPage + 1} of $pageCount',
-                child: Text(
-                  '${currentPage + 1} / $pageCount',
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: Colors.white,
-                        letterSpacing: 1.5,
-                      ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Semantics(
+                  label: 'Page ${currentPage + 1} of $pageCount',
+                  child: Text(
+                    '${currentPage + 1} / $pageCount',
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color: Colors.white,
+                          letterSpacing: 1.5,
+                        ),
+                  ),
                 ),
-              ),
+                const SizedBox(width: 24),
+                _OrientationToggleButton(
+                  orientation: playerOrientation,
+                  onTap: onOrientationToggle,
+                ),
+              ],
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orientation toggle button
+// ---------------------------------------------------------------------------
+
+/// Icon button that cycles through orientation lock modes.
+///
+/// Shows a different icon for each [PlayerOrientation] value and calls
+/// [onTap] when pressed.
+class _OrientationToggleButton extends StatelessWidget {
+  const _OrientationToggleButton({
+    required this.orientation,
+    required this.onTap,
+  });
+
+  final PlayerOrientation orientation;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = switch (orientation) {
+      PlayerOrientation.auto => Icons.screen_rotation,
+      PlayerOrientation.portrait => Icons.screen_lock_portrait,
+      PlayerOrientation.landscape => Icons.screen_lock_landscape,
+    };
+
+    final label = switch (orientation) {
+      PlayerOrientation.auto => 'Screen rotation: auto',
+      PlayerOrientation.portrait => 'Screen rotation: locked portrait',
+      PlayerOrientation.landscape => 'Screen rotation: locked landscape',
+    };
+
+    return Semantics(
+      label: label,
+      button: true,
+      child: IconButton(
+        key: const Key('orientation_toggle_button'),
+        onPressed: onTap,
+        icon: Icon(icon, color: Colors.white),
+        tooltip: label,
       ),
     );
   }

--- a/lib/features/player/viewmodels/notation_player_view_model.dart
+++ b/lib/features/player/viewmodels/notation_player_view_model.dart
@@ -4,12 +4,13 @@
 // play-count on successful load via [NotationRepository.updatePlayCount], and
 // exposes state as a sealed [NotationPlayerState] hierarchy.
 //
-// Also tracks the active page index and chrome-visibility flag used by
-// [NotationPlayerScreen] for the fade-in/fade-out UI affordance.
+// Also tracks the active page index, chrome-visibility flag, and
+// player-orientation lock used by [NotationPlayerScreen].
 //
 // Construction:
 //   NotationPlayerViewModel(
 //     notationRepository,
+//     preferencesRepository: prefsRepo,
 //     notationId: id,
 //     startPage: 0,    // optional, defaults to 0
 //   )
@@ -24,7 +25,19 @@ import 'dart:developer';
 import 'package:flutter/foundation.dart';
 
 import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
 import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Public constant
+// ---------------------------------------------------------------------------
+
+/// Duration after which the chrome (title + toolbar) fades out.
+///
+/// Exposed as a top-level constant so widget tests can assert on it
+/// without needing access to private state.
+const Duration kChromeFadeDuration = Duration(seconds: 3);
 
 // ---------------------------------------------------------------------------
 // State hierarchy
@@ -89,27 +102,32 @@ final class NotationPlayerStateError extends NotationPlayerState {
 /// ViewModel for the full-screen notation player screen.
 ///
 /// Loads a [NotationDetail], records the play count on success, and exposes
-/// per-page navigation state and chrome-visibility state used by the
-/// [NotationPlayerScreen].
+/// per-page navigation state, chrome-visibility state, and orientation lock
+/// used by the [NotationPlayerScreen].
 ///
 /// State management contract:
 /// - [state] drives the primary display state.
 /// - [currentPage] is the 0-indexed currently-visible page.
 /// - [isChromeVisible] controls whether the title bar and toolbar are shown.
+/// - [playerOrientation] is the active screen orientation lock.
 class NotationPlayerViewModel extends ChangeNotifier {
   /// Creates a [NotationPlayerViewModel].
   ///
   /// Parameters:
   /// - [_repository]: Source of truth for notation loading and play-count.
+  /// - [preferencesRepository]: Persists the player orientation setting.
   /// - [notationId]: UUIDv4 of the notation to load.
   /// - [startPage]: 0-indexed page to open initially. Defaults to `0`.
   NotationPlayerViewModel(
     this._repository, {
+    required PreferencesRepository preferencesRepository,
     required this.notationId,
     int startPage = 0,
-  }) : _currentPage = startPage;
+  })  : _preferencesRepository = preferencesRepository,
+        _currentPage = startPage;
 
   final NotationRepository _repository;
+  final PreferencesRepository _preferencesRepository;
 
   /// UUIDv4 of the notation being displayed.
   final String notationId;
@@ -117,6 +135,7 @@ class NotationPlayerViewModel extends ChangeNotifier {
   NotationPlayerState _state = const NotationPlayerStateIdle();
   int _currentPage;
   bool _isChromeVisible = true;
+  PlayerOrientation _playerOrientation = PlayerOrientation.auto;
 
   // -------------------------------------------------------------------------
   // Public getters
@@ -130,8 +149,13 @@ class NotationPlayerViewModel extends ChangeNotifier {
 
   /// Whether the title bar and bottom toolbar are visible.
   ///
-  /// Fades out after 2 seconds of inactivity; restored on tap.
+  /// Fades out after [kChromeFadeDuration] of inactivity; restored on tap.
   bool get isChromeVisible => _isChromeVisible;
+
+  /// The active screen orientation lock for the player.
+  ///
+  /// Defaults to [PlayerOrientation.auto].
+  PlayerOrientation get playerOrientation => _playerOrientation;
 
   /// Total number of pages in the loaded notation.
   ///
@@ -225,5 +249,45 @@ class NotationPlayerViewModel extends ChangeNotifier {
   void hideChrome() {
     _isChromeVisible = false;
     notifyListeners();
+  }
+
+  // -------------------------------------------------------------------------
+  // Orientation lock
+  // -------------------------------------------------------------------------
+
+  /// Sets the screen orientation lock to [orientation].
+  ///
+  /// Persists the new value to [PreferencesRepository.updatePlayerOrientation]
+  /// and notifies listeners. Does nothing if [orientation] equals the current
+  /// value.
+  ///
+  /// Parameters:
+  /// - [orientation]: The new [PlayerOrientation] to apply.
+  Future<void> setOrientation(PlayerOrientation orientation) async {
+    if (_playerOrientation == orientation) return;
+    _playerOrientation = orientation;
+    notifyListeners();
+    try {
+      await _preferencesRepository.updatePlayerOrientation(orientation);
+    } on Exception catch (e, st) {
+      log(
+        'NotationPlayerViewModel: updatePlayerOrientation failed — $e',
+        name: 'NotationPlayerViewModel',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
+  /// Cycles the orientation lock through auto → portrait → landscape → auto.
+  ///
+  /// Persists the new value via [setOrientation].
+  Future<void> cycleOrientation() async {
+    final next = switch (_playerOrientation) {
+      PlayerOrientation.auto => PlayerOrientation.portrait,
+      PlayerOrientation.portrait => PlayerOrientation.landscape,
+      PlayerOrientation.landscape => PlayerOrientation.auto,
+    };
+    await setOrientation(next);
   }
 }

--- a/lib/features/settings/data/user_preferences_repository_impl.dart
+++ b/lib/features/settings/data/user_preferences_repository_impl.dart
@@ -70,6 +70,7 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
         defaultSort: Value(preferences.defaultSort.dbValue),
         defaultView: Value(preferences.defaultView.dbValue),
         tagsSeeded: Value(preferences.tagsSeeded ? 1 : 0),
+        playerOrientation: Value(preferences.playerOrientation.dbValue),
       ),
     );
     log(
@@ -142,6 +143,29 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
   }
 
   @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    final existing = await _dao.getPreferences();
+    await _dao.upsertPreferences(
+      UserPreferencesTableCompanion(
+        id: const Value(_kSingletonId),
+        userName: Value(existing.userName),
+        themeMode: Value(existing.themeMode),
+        colorSchemeMode: Value(existing.colorSchemeMode),
+        seedColor: Value(existing.seedColor),
+        defaultSort: Value(existing.defaultSort),
+        defaultView: Value(existing.defaultView),
+        tagsSeeded: Value(existing.tagsSeeded),
+        playerOrientation: Value(orientation.dbValue),
+      ),
+    );
+    log(
+      'UserPreferencesRepositoryImpl: playerOrientation set to '
+      '${orientation.dbValue}',
+      name: 'UserPreferencesRepository',
+    );
+  }
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {
     final existing = await _dao.getPreferences();
     await _dao.upsertPreferences(
@@ -185,6 +209,11 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
       orElse: () => ViewMode.list,
     );
 
+    final playerOrientation = PlayerOrientation.values.firstWhere(
+      (o) => o.dbValue == row.playerOrientation,
+      orElse: () => PlayerOrientation.auto,
+    );
+
     return UserPreferences(
       userName: row.userName,
       themeMode: themeMode,
@@ -193,6 +222,7 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
       defaultSort: defaultSort,
       defaultView: defaultView,
       tagsSeeded: row.tagsSeeded == 1,
+      playerOrientation: playerOrientation,
     );
   }
 }

--- a/lib/shared/models/user_preferences.dart
+++ b/lib/shared/models/user_preferences.dart
@@ -104,6 +104,28 @@ enum ViewMode {
   final String dbValue;
 }
 
+/// The preferred screen orientation lock for the notation player.
+///
+/// Mirrors the `CHECK (player_orientation IN ('auto', 'portrait', 'landscape'))`
+/// DB constraint.
+@JsonEnum(valueField: 'dbValue')
+enum PlayerOrientation {
+  /// Follow the device sensor (no lock).
+  auto('auto'),
+
+  /// Lock to portrait mode.
+  portrait('portrait'),
+
+  /// Lock to landscape mode.
+  landscape('landscape');
+
+  /// Creates a [PlayerOrientation] with the given database string value.
+  const PlayerOrientation(this.dbValue);
+
+  /// The string value used in the database and JSON serialization.
+  final String dbValue;
+}
+
 /// Immutable domain model for the singleton user preferences row.
 ///
 /// There is exactly one [UserPreferences] in the database (enforced by
@@ -123,6 +145,8 @@ class UserPreferences {
   /// - [defaultView]: Default view layout for the notation library.
   /// - [tagsSeeded]: Whether the 5 default tags have been seeded. Defaults to
   ///   `false`.
+  /// - [playerOrientation]: Screen orientation lock for the notation player.
+  ///   Defaults to [PlayerOrientation.auto].
   const UserPreferences({
     required this.userName,
     required this.themeMode,
@@ -131,6 +155,7 @@ class UserPreferences {
     required this.defaultSort,
     required this.defaultView,
     this.tagsSeeded = false,
+    this.playerOrientation = PlayerOrientation.auto,
   });
 
   /// Display name shown in the application UI.
@@ -157,6 +182,11 @@ class UserPreferences {
   /// first successful seed. Subsequent launches skip the seed.
   final bool tagsSeeded;
 
+  /// Preferred screen orientation lock for the notation player.
+  ///
+  /// Defaults to [PlayerOrientation.auto] (sensor-driven, no lock).
+  final PlayerOrientation playerOrientation;
+
   /// Returns a copy of this [UserPreferences] with the specified fields
   /// replaced.
   ///
@@ -169,6 +199,7 @@ class UserPreferences {
     SortOrder? defaultSort,
     ViewMode? defaultView,
     bool? tagsSeeded,
+    PlayerOrientation? playerOrientation,
   }) =>
       UserPreferences(
         userName: userName ?? this.userName,
@@ -178,6 +209,7 @@ class UserPreferences {
         defaultSort: defaultSort ?? this.defaultSort,
         defaultView: defaultView ?? this.defaultView,
         tagsSeeded: tagsSeeded ?? this.tagsSeeded,
+        playerOrientation: playerOrientation ?? this.playerOrientation,
       );
 
   /// Deserializes [UserPreferences] from a JSON map.
@@ -198,7 +230,8 @@ class UserPreferences {
           seedColor == other.seedColor &&
           defaultSort == other.defaultSort &&
           defaultView == other.defaultView &&
-          tagsSeeded == other.tagsSeeded;
+          tagsSeeded == other.tagsSeeded &&
+          playerOrientation == other.playerOrientation;
 
   @override
   int get hashCode => Object.hash(
@@ -209,6 +242,7 @@ class UserPreferences {
         defaultSort,
         defaultView,
         tagsSeeded,
+        playerOrientation,
       );
 
   @override

--- a/lib/shared/models/user_preferences.g.dart
+++ b/lib/shared/models/user_preferences.g.dart
@@ -16,6 +16,9 @@ UserPreferences _$UserPreferencesFromJson(Map<String, dynamic> json) =>
       defaultSort: $enumDecode(_$SortOrderEnumMap, json['default_sort']),
       defaultView: $enumDecode(_$ViewModeEnumMap, json['default_view']),
       tagsSeeded: json['tags_seeded'] as bool? ?? false,
+      playerOrientation: $enumDecodeNullable(
+              _$PlayerOrientationEnumMap, json['player_orientation']) ??
+          PlayerOrientation.auto,
     );
 
 Map<String, dynamic> _$UserPreferencesToJson(UserPreferences instance) =>
@@ -27,6 +30,8 @@ Map<String, dynamic> _$UserPreferencesToJson(UserPreferences instance) =>
       'default_sort': _$SortOrderEnumMap[instance.defaultSort]!,
       'default_view': _$ViewModeEnumMap[instance.defaultView]!,
       'tags_seeded': instance.tagsSeeded,
+      'player_orientation':
+          _$PlayerOrientationEnumMap[instance.playerOrientation]!,
     };
 
 const _$AppThemeModeEnumMap = {
@@ -53,4 +58,10 @@ const _$SortOrderEnumMap = {
 
 const _$ViewModeEnumMap = {
   ViewMode.list: 'list',
+};
+
+const _$PlayerOrientationEnumMap = {
+  PlayerOrientation.auto: 'auto',
+  PlayerOrientation.portrait: 'portrait',
+  PlayerOrientation.landscape: 'landscape',
 };

--- a/lib/shared/repositories/preferences_repository.dart
+++ b/lib/shared/repositories/preferences_repository.dart
@@ -55,6 +55,14 @@ abstract interface class PreferencesRepository
   /// - [colorHex]: A Catppuccin hex string (e.g. `'#f38ba8'`), or `null`.
   Future<void> updateSeedColor(String? colorHex);
 
+  /// Updates the `player_orientation` field to [orientation].
+  ///
+  /// All other preference fields are left unchanged.
+  ///
+  /// Parameters:
+  /// - [orientation]: The new [PlayerOrientation] to persist.
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation);
+
   /// Convenience method to flip the `tagsSeeded` flag.
   ///
   /// Parameters:

--- a/test/unit/core/database/migration_test.dart
+++ b/test/unit/core/database/migration_test.dart
@@ -1,4 +1,4 @@
-// Migration tests for AppDatabase — schema v3.
+// Migration tests for AppDatabase — schema v4.
 //
 // Verifies that [MigrationStrategy.onCreate] produces the exact schema
 // described in docs/02-technical/data-model.md, including:
@@ -6,7 +6,7 @@
 //   - All 9 indexes (partial and non-partial)
 //   - The FTS5 virtual table (notations_fts) and its 3 sync triggers
 //   - Seed data: 5 default tags and the singleton user_preferences row
-//   - schemaVersion == 3
+//   - schemaVersion == 4
 //
 // [validateDatabaseSchema] (from drift_dev/api/migrations_native.dart) is
 // used to compare the live schema against Drift's reference schema, giving
@@ -110,18 +110,18 @@ void main() {
   setUpAll(() => driftRuntimeOptions.dontWarnAboutMultipleDatabases = true);
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — schema version', () {
+  group('Migration v4 — schema version', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
 
-    test('schemaVersion is 3', () {
-      expect(db.schemaVersion, 3);
+    test('schemaVersion is 4', () {
+      expect(db.schemaVersion, 4);
     });
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — Drift schema validation', () {
+  group('Migration v4 — Drift schema validation', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -146,7 +146,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — table presence', () {
+  group('Migration v4 — table presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -160,7 +160,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — index presence', () {
+  group('Migration v4 — index presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -174,7 +174,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — FTS5 virtual table and triggers', () {
+  group('Migration v4 — FTS5 virtual table and triggers', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -219,7 +219,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — seed data', () {
+  group('Migration v4 — seed data', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -260,11 +260,12 @@ void main() {
       expect(prefs.defaultView, 'list');
       expect(prefs.userName, 'Musician');
       expect(prefs.tagsSeeded, 0);
+      expect(prefs.playerOrientation, 'auto');
     });
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v3 — forTesting mode has no seed data', () {
+  group('Migration v4 — forTesting mode has no seed data', () {
     late AppDatabase db;
     setUp(() {
       db = AppDatabase.forTesting();
@@ -332,8 +333,7 @@ void main() {
     });
     tearDown(() => db.close());
 
-    test(
-        'instrument_classes_table has deleted_at column after upgrade',
+    test('instrument_classes_table has deleted_at column after upgrade',
         () async {
       final columns = await db
           .customSelect(
@@ -364,6 +364,45 @@ void main() {
         row.deletedAt,
         isNull,
         reason: 'deleted_at should default to NULL',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('Migration v3 → v4 upgrade', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      // Open a v4 in-memory database and trigger schema creation.
+      db = AppDatabase.forTesting();
+      await db.select(db.notationsTable).get();
+    });
+    tearDown(() => db.close());
+
+    test('user_preferences_table has player_orientation column after upgrade',
+        () async {
+      final columns = await db
+          .customSelect(
+            "PRAGMA table_info('user_preferences_table')",
+          )
+          .get();
+      final columnNames = columns.map((r) => r.read<String>('name')).toList();
+      expect(
+        columnNames,
+        contains('player_orientation'),
+        reason: 'player_orientation column missing from user_preferences_table',
+      );
+    });
+
+    test('player_orientation column has default value auto', () async {
+      await db.into(db.userPreferencesTable).insert(
+            const UserPreferencesTableCompanion(),
+          );
+      final prefs = await db.select(db.userPreferencesTable).getSingle();
+      expect(
+        prefs.playerOrientation,
+        'auto',
+        reason: 'player_orientation should default to auto',
       );
     });
   });

--- a/test/unit/features/capture/viewmodels/capture_session_view_model_test.dart
+++ b/test/unit/features/capture/viewmodels/capture_session_view_model_test.dart
@@ -139,7 +139,9 @@ void main() {
       'skips path and continues when file read throws',
       () async {
         fakeReader = FakeFileReader(
-          data: {'/good.jpg': Uint8List.fromList([1])},
+          data: {
+            '/good.jpg': Uint8List.fromList([1])
+          },
           errorPaths: {'/bad.jpg'},
         );
         viewModel = CaptureSessionViewModel(fileReader: fakeReader);

--- a/test/unit/features/custom_fields/data/custom_field_repository_impl_test.dart
+++ b/test/unit/features/custom_fields/data/custom_field_repository_impl_test.dart
@@ -105,8 +105,7 @@ void main() {
     test('persists the definition to the database', () async {
       await repo.createDefinition('started_date', 'date');
 
-      final rows =
-          await db.select(db.customFieldDefinitionsTable).get();
+      final rows = await db.select(db.customFieldDefinitionsTable).get();
       expect(rows, hasLength(1));
       expect(rows.first.keyName, 'started_date');
     });
@@ -196,8 +195,7 @@ void main() {
     test('persists changes to the database', () async {
       await repo.updateDefinition(existing.id, keyName: 'persisted_key');
 
-      final rows =
-          await db.select(db.customFieldDefinitionsTable).get();
+      final rows = await db.select(db.customFieldDefinitionsTable).get();
       expect(rows.first.keyName, 'persisted_key');
     });
 
@@ -235,8 +233,7 @@ void main() {
     test('removes the definition row from the database', () async {
       await repo.deleteDefinition(existing.id);
 
-      final rows =
-          await db.select(db.customFieldDefinitionsTable).get();
+      final rows = await db.select(db.customFieldDefinitionsTable).get();
       expect(rows, isEmpty);
     });
 

--- a/test/unit/features/custom_fields/viewmodels/custom_fields_view_model_test.dart
+++ b/test/unit/features/custom_fields/viewmodels/custom_fields_view_model_test.dart
@@ -20,8 +20,7 @@ import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
 
 class FakeCustomFieldRepository implements CustomFieldRepository {
   final _defs = <String, CustomFieldDefinition>{};
-  final _controller =
-      StreamController<List<CustomFieldDefinition>>.broadcast();
+  final _controller = StreamController<List<CustomFieldDefinition>>.broadcast();
 
   Object? watchError;
   Object? createError;
@@ -47,8 +46,7 @@ class FakeCustomFieldRepository implements CustomFieldRepository {
     final def = CustomFieldDefinition(
       id: 'fake-${_defs.length}',
       keyName: keyName,
-      fieldType: CustomFieldType.values
-          .firstWhere((e) => e.name == fieldType),
+      fieldType: CustomFieldType.values.firstWhere((e) => e.name == fieldType),
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
     );
@@ -96,8 +94,7 @@ class FakeCustomFieldRepository implements CustomFieldRepository {
 // Helper
 // ---------------------------------------------------------------------------
 
-CustomFieldDefinition _makeDef(String id, String key) =>
-    CustomFieldDefinition(
+CustomFieldDefinition _makeDef(String id, String key) => CustomFieldDefinition(
       id: id,
       keyName: key,
       fieldType: CustomFieldType.text,

--- a/test/unit/features/edit/viewmodels/edit_notation_view_model_test.dart
+++ b/test/unit/features/edit/viewmodels/edit_notation_view_model_test.dart
@@ -278,12 +278,14 @@ void main() {
 
     test('artists pre-populated from notation', () async {
       repo.notationToReturn = _makeDetail(
-        notation: _makeNotation(artists: ['Pt. Ravi Shankar', 'Ustad Ali Khan']),
+        notation:
+            _makeNotation(artists: ['Pt. Ravi Shankar', 'Ustad Ali Khan']),
       );
       final vm = makeVm();
       await vm.loadNotation('notation-1');
 
-      expect(vm.formState.artists, equals(['Pt. Ravi Shankar', 'Ustad Ali Khan']));
+      expect(
+          vm.formState.artists, equals(['Pt. Ravi Shankar', 'Ustad Ali Khan']));
     });
 
     test('dateWritten pre-populated from notation', () async {
@@ -349,8 +351,7 @@ void main() {
       expect(vm.formState.selectedTagIds, containsAll(['tag-1', 'tag-2']));
     });
 
-    test(
-        'customFieldValues pre-populated from text custom field values',
+    test('customFieldValues pre-populated from text custom field values',
         () async {
       repo.notationToReturn = _makeDetail(
         customFieldValues: [
@@ -533,8 +534,7 @@ void main() {
 
   group('isTitleValid', () {
     test('returns false when title is empty', () async {
-      repo.notationToReturn =
-          _makeDetail(notation: _makeNotation(title: ''));
+      repo.notationToReturn = _makeDetail(notation: _makeNotation(title: ''));
       final vm = makeVm();
       await vm.loadNotation('notation-1');
       expect(vm.isTitleValid, isFalse);
@@ -562,8 +562,7 @@ void main() {
 
   group('save', () {
     test('no-op when title is empty', () async {
-      repo.notationToReturn =
-          _makeDetail(notation: _makeNotation(title: ''));
+      repo.notationToReturn = _makeDetail(notation: _makeNotation(title: ''));
       final vm = makeVm();
       await vm.loadNotation('notation-1');
 
@@ -589,9 +588,7 @@ void main() {
       expect(repo.lastUpdateId, equals('notation-1'));
     });
 
-    test(
-        'calls updateNotation with correct id and draft on success',
-        () async {
+    test('calls updateNotation with correct id and draft on success', () async {
       repo.notationToReturn = _makeDetail(
         notation: _makeNotation(title: 'Raag Bhairav'),
         tags: [_makeTag(id: 'tag-1')],
@@ -657,11 +654,12 @@ void main() {
       expect(error.message, contains('update failed'));
     });
 
-    test(
-        'passes updatedPages pages as SavedPage list to updateNotation draft',
+    test('passes updatedPages pages as SavedPage list to updateNotation draft',
         () async {
       repo.notationToReturn = _makeDetail(
-        pages: [_makePage(id: 'p1', imagePath: 'notations/n1/page_0_original.jpg')],
+        pages: [
+          _makePage(id: 'p1', imagePath: 'notations/n1/page_0_original.jpg')
+        ],
       );
       repo.updatedNotation = _makeNotation();
       final vm = makeVm();
@@ -693,14 +691,16 @@ void main() {
 
       final updatedPages = [
         _makePage(id: 'p1', renderParams: '{"filter":"grayscale"}'),
-        _makePage(id: 'p2', pageOrder: 1, renderParams: '{"rotation_degrees":90}'),
+        _makePage(
+            id: 'p2', pageOrder: 1, renderParams: '{"rotation_degrees":90}'),
       ];
 
       await vm.save(updatedPages: updatedPages);
 
       expect(repo.pageRenderParamsUpdates, hasLength(2));
       expect(repo.pageRenderParamsUpdates[0].$1, equals('p1'));
-      expect(repo.pageRenderParamsUpdates[0].$2, equals('{"filter":"grayscale"}'));
+      expect(
+          repo.pageRenderParamsUpdates[0].$2, equals('{"filter":"grayscale"}'));
       expect(repo.pageRenderParamsUpdates[1].$1, equals('p2'));
     });
   });

--- a/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
@@ -1,0 +1,296 @@
+// Unit tests for orientation-lock and chrome-fade behaviour added to
+// NotationPlayerViewModel in task #93.
+//
+// Covers:
+//   playerOrientation    → initial value / setOrientation / persistence
+//   chrome fade timer    → 3 s constant (not 2 s)
+//   PreferencesRepository interaction → updatePlayerOrientation called on change
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/player/viewmodels/notation_player_view_model.dart';
+import 'package:swaralipi/shared/models/custom_field_value.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  NotationDetail? _detail;
+
+  void setDetail(NotationDetail? d) => _detail = d;
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async => _detail;
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> softDelete(String id) async => throw UnimplementedError();
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async =>
+      throw UnimplementedError();
+}
+
+class FakePreferencesRepository implements PreferencesRepository {
+  PlayerOrientation? lastSavedOrientation;
+  UserPreferences _prefs = const UserPreferences(
+    userName: 'Test',
+    themeMode: AppThemeMode.system,
+    colorSchemeMode: ColorSchemeMode.catppuccin,
+    defaultSort: SortOrder.createdAtDesc,
+    defaultView: ViewMode.list,
+    playerOrientation: PlayerOrientation.auto,
+  );
+
+  @override
+  Future<UserPreferences> getPreferences() async => _prefs;
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {
+    _prefs = preferences;
+  }
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    lastSavedOrientation = orientation;
+    _prefs = _prefs.copyWith(playerOrientation: orientation);
+  }
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+NotationDetail _makeDetail(String id, int pageCount) => NotationDetail(
+      notation: Notation(
+        id: id,
+        title: 'Test Notation',
+        artists: const [],
+        languages: const [],
+        notes: '',
+        playCount: 0,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      ),
+      pages: List.generate(
+        pageCount,
+        (i) => NotationPage(
+          id: 'page-$i',
+          notationId: id,
+          pageOrder: i,
+          imagePath: 'notations/$id/page_${i}_original.jpg',
+          renderParams: '{}',
+          createdAt: '2024-01-01T00:00:00Z',
+        ),
+      ),
+      tags: const <Tag>[],
+      customFieldValues: const <CustomFieldValue>[],
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository notationRepo;
+  late FakePreferencesRepository prefsRepo;
+
+  setUp(() {
+    notationRepo = FakeNotationRepository();
+    prefsRepo = FakePreferencesRepository();
+  });
+
+  // -------------------------------------------------------------------------
+  // Chrome fade duration constant
+  // -------------------------------------------------------------------------
+
+  group('chrome fade duration', () {
+    test('_kChromeFadeDuration is 3 seconds', () {
+      expect(
+        kChromeFadeDuration,
+        equals(const Duration(seconds: 3)),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial orientation state
+  // -------------------------------------------------------------------------
+
+  group('initial orientation', () {
+    test('playerOrientation defaults to auto before load', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      expect(vm.playerOrientation, equals(PlayerOrientation.auto));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setOrientation
+  // -------------------------------------------------------------------------
+
+  group('setOrientation', () {
+    test('updates playerOrientation to portrait', () async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setOrientation(PlayerOrientation.portrait);
+
+      expect(vm.playerOrientation, equals(PlayerOrientation.portrait));
+    });
+
+    test('updates playerOrientation to landscape', () async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setOrientation(PlayerOrientation.landscape);
+
+      expect(vm.playerOrientation, equals(PlayerOrientation.landscape));
+    });
+
+    test('notifies listeners when orientation changes', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+
+      await vm.setOrientation(PlayerOrientation.portrait);
+
+      expect(notified, isTrue);
+    });
+
+    test('persists orientation to PreferencesRepository', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setOrientation(PlayerOrientation.landscape);
+
+      expect(
+        prefsRepo.lastSavedOrientation,
+        equals(PlayerOrientation.landscape),
+      );
+    });
+
+    test('does not notify when same orientation is set again', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      await vm.setOrientation(PlayerOrientation.portrait);
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+
+      await vm.setOrientation(PlayerOrientation.portrait);
+
+      expect(notified, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Orientation cycle
+  // -------------------------------------------------------------------------
+
+  group('cycleOrientation', () {
+    test('cycles auto → portrait → landscape → auto', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      expect(vm.playerOrientation, equals(PlayerOrientation.auto));
+
+      await vm.cycleOrientation();
+      expect(vm.playerOrientation, equals(PlayerOrientation.portrait));
+
+      await vm.cycleOrientation();
+      expect(vm.playerOrientation, equals(PlayerOrientation.landscape));
+
+      await vm.cycleOrientation();
+      expect(vm.playerOrientation, equals(PlayerOrientation.auto));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Orientation preserved across page swipes
+  // -------------------------------------------------------------------------
+
+  group('orientation preserved across page swipes', () {
+    test('goToPage does not reset orientation', () async {
+      notationRepo.setDetail(_makeDetail('n1', 3));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      await vm.loadNotation();
+      await vm.setOrientation(PlayerOrientation.landscape);
+
+      vm.goToPage(2);
+
+      expect(vm.playerOrientation, equals(PlayerOrientation.landscape));
+    });
+  });
+}

--- a/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
@@ -19,7 +19,9 @@ import 'package:swaralipi/shared/models/notation_draft.dart';
 import 'package:swaralipi/shared/models/notation_page.dart';
 import 'package:swaralipi/shared/models/saved_page.dart';
 import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
 import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -74,6 +76,35 @@ class FakeNotationRepository implements NotationRepository {
       throw UnimplementedError();
 }
 
+class FakePreferencesRepository implements PreferencesRepository {
+  @override
+  Future<UserPreferences> getPreferences() async => const UserPreferences(
+        userName: 'Test',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+      );
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -111,9 +142,11 @@ NotationDetail _makeDetail(String id, int pageCount) => NotationDetail(
 
 void main() {
   late FakeNotationRepository repo;
+  late FakePreferencesRepository prefsRepo;
 
   setUp(() {
     repo = FakeNotationRepository();
+    prefsRepo = FakePreferencesRepository();
   });
 
   // -------------------------------------------------------------------------
@@ -122,22 +155,39 @@ void main() {
 
   group('initial state', () {
     test('state is idle before loadNotation is called', () {
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       expect(vm.state, isA<NotationPlayerStateIdle>());
     });
 
     test('isChromVisible is true initially', () {
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       expect(vm.isChromeVisible, isTrue);
     });
 
     test('currentPage equals startPage parameter', () {
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1', startPage: 2);
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+        startPage: 2,
+      );
       expect(vm.currentPage, equals(2));
     });
 
     test('currentPage defaults to 0 when startPage not provided', () {
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       expect(vm.currentPage, equals(0));
     });
   });
@@ -149,7 +199,11 @@ void main() {
   group('loadNotation — success', () {
     test('transitions through loading to success', () async {
       repo.setDetail(_makeDetail('n1', 3));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       final states = <NotationPlayerState>[];
       vm.addListener(() => states.add(vm.state));
@@ -163,7 +217,11 @@ void main() {
     test('success state contains correct detail', () async {
       final detail = _makeDetail('n1', 3);
       repo.setDetail(detail);
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 
@@ -174,7 +232,11 @@ void main() {
 
     test('pageCount returns number of pages after success', () async {
       repo.setDetail(_makeDetail('n1', 4));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 
@@ -183,7 +245,11 @@ void main() {
 
     test('calls updatePlayCount with notationId after success', () async {
       repo.setDetail(_makeDetail('n1', 2));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 
@@ -198,7 +264,11 @@ void main() {
   group('loadNotation — notFound', () {
     test('transitions to notFound when repository returns null', () async {
       repo.setDetail(null);
-      final vm = NotationPlayerViewModel(repo, notationId: 'missing');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'missing',
+      );
 
       await vm.loadNotation();
 
@@ -207,7 +277,11 @@ void main() {
 
     test('does not call updatePlayCount when not found', () async {
       repo.setDetail(null);
-      final vm = NotationPlayerViewModel(repo, notationId: 'missing');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'missing',
+      );
 
       await vm.loadNotation();
 
@@ -222,7 +296,11 @@ void main() {
   group('loadNotation — error', () {
     test('transitions to error state on exception', () async {
       repo.setLoadError(Exception('db error'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 
@@ -231,7 +309,11 @@ void main() {
 
     test('error message is propagated', () async {
       repo.setLoadError(Exception('db error'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 
@@ -246,13 +328,21 @@ void main() {
 
   group('pageCount', () {
     test('returns 0 before load', () {
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       expect(vm.pageCount, equals(0));
     });
 
     test('returns 0 in error state', () async {
       repo.setLoadError(Exception('err'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       expect(vm.pageCount, equals(0));
@@ -266,7 +356,11 @@ void main() {
   group('goToPage', () {
     test('updates currentPage to valid index', () async {
       repo.setDetail(_makeDetail('n1', 5));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       vm.goToPage(3);
@@ -276,7 +370,11 @@ void main() {
 
     test('clamps negative index to 0', () async {
       repo.setDetail(_makeDetail('n1', 5));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       vm.goToPage(-1);
@@ -286,7 +384,11 @@ void main() {
 
     test('clamps out-of-bounds index to last page', () async {
       repo.setDetail(_makeDetail('n1', 5));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       vm.goToPage(10);
@@ -296,7 +398,11 @@ void main() {
 
     test('notifies listeners on page change', () async {
       repo.setDetail(_makeDetail('n1', 3));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       var notified = false;
@@ -314,7 +420,11 @@ void main() {
   group('chrome visibility', () {
     test('showChrome sets isChromeVisible to true and notifies', () async {
       repo.setDetail(_makeDetail('n1', 2));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       var notified = false;
@@ -327,7 +437,11 @@ void main() {
 
     test('hideChrome sets isChromeVisible to false and notifies', () async {
       repo.setDetail(_makeDetail('n1', 2));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
       await vm.loadNotation();
 
       var notified = false;
@@ -348,7 +462,11 @@ void main() {
         () async {
       repo.setDetail(_makeDetail('n1', 2));
       repo.setUpdatePlayCountError(Exception('update failed'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       await vm.loadNotation();
 

--- a/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
+++ b/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
@@ -73,6 +73,11 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateTagsSeeded({required bool value}) async {
     _prefs = _prefs.copyWith(tagsSeeded: value);
   }
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    _prefs = _prefs.copyWith(playerOrientation: orientation);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/features/trash/data/trash_repository_impl_test.dart
+++ b/test/unit/features/trash/data/trash_repository_impl_test.dart
@@ -82,8 +82,7 @@ class FakeRow {
   final String title;
   final String? deletedAt;
 
-  FakeRow copyWith({String? deletedAt, bool clearDeletedAt = false}) =>
-      FakeRow(
+  FakeRow copyWith({String? deletedAt, bool clearDeletedAt = false}) => FakeRow(
         id: id,
         title: title,
         deletedAt: clearDeletedAt ? null : (deletedAt ?? this.deletedAt),

--- a/test/widget/features/player/notation_player_screen_orientation_test.dart
+++ b/test/widget/features/player/notation_player_screen_orientation_test.dart
@@ -1,0 +1,314 @@
+// Widget tests for orientation toggle and chrome fade behaviour in
+// NotationPlayerScreen — task #93.
+//
+// Covers:
+//   - Orientation toggle button present in player chrome
+//   - Tapping toggle button calls vm.cycleOrientation
+//   - Chrome fade timer uses 3 s constant
+//   - AnimatedOpacity wraps chrome widgets
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/features/player/screens/notation_player_screen.dart';
+import 'package:swaralipi/features/player/viewmodels/notation_player_view_model.dart';
+import 'package:swaralipi/shared/models/custom_field_value.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation_page.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  NotationDetail? _detail;
+
+  void setDetail(NotationDetail? d) => _detail = d;
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async => _detail;
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> softDelete(String id) async => throw UnimplementedError();
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async =>
+      throw UnimplementedError();
+}
+
+class FakePreferencesRepository implements PreferencesRepository {
+  PlayerOrientation _orientation = PlayerOrientation.auto;
+  int cycleCallCount = 0;
+
+  @override
+  Future<UserPreferences> getPreferences() async => UserPreferences(
+        userName: 'Test',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+        playerOrientation: _orientation,
+      );
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    _orientation = orientation;
+  }
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+NotationDetail _makeDetail(String id, int pageCount, {String title = 'Test'}) =>
+    NotationDetail(
+      notation: Notation(
+        id: id,
+        title: title,
+        artists: const [],
+        languages: const [],
+        notes: '',
+        playCount: 0,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      ),
+      pages: List.generate(
+        pageCount,
+        (i) => NotationPage(
+          id: 'page-$i',
+          notationId: id,
+          pageOrder: i,
+          imagePath: 'notations/$id/page_${i}_original.jpg',
+          renderParams: '{}',
+          createdAt: '2024-01-01T00:00:00Z',
+        ),
+      ),
+      tags: const <Tag>[],
+      customFieldValues: const <CustomFieldValue>[],
+    );
+
+Widget _buildScreen(
+  NotationPlayerViewModel vm,
+) =>
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: ChangeNotifierProvider<NotationPlayerViewModel>(
+        create: (_) => vm,
+        child: const NotationPlayerScreen(),
+      ),
+    );
+
+Future<NotationPlayerViewModel> _pumpAndLoad(
+  WidgetTester tester,
+  NotationPlayerViewModel vm,
+) async {
+  await tester.pumpWidget(_buildScreen(vm));
+  await tester.pump();
+  await tester.pump();
+  return vm;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository notationRepo;
+  late FakePreferencesRepository prefsRepo;
+
+  setUp(() {
+    notationRepo = FakeNotationRepository();
+    prefsRepo = FakePreferencesRepository();
+  });
+
+  // -------------------------------------------------------------------------
+  // Orientation toggle button presence
+  // -------------------------------------------------------------------------
+
+  group('orientation toggle button', () {
+    testWidgets('shows orientation toggle button in player chrome',
+        (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      expect(
+          find.byKey(const Key('orientation_toggle_button')), findsOneWidget);
+    });
+
+    testWidgets('orientation button icon changes with orientation state',
+        (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      // Default is auto orientation — screen_rotation icon
+      expect(find.byIcon(Icons.screen_rotation), findsOneWidget);
+    });
+
+    testWidgets('tapping orientation button calls cycleOrientation',
+        (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      // Initially auto.
+      expect(vm.playerOrientation, equals(PlayerOrientation.auto));
+
+      await tester.tap(find.byKey(const Key('orientation_toggle_button')));
+      await tester.pump();
+
+      // After one tap, orientation should be portrait.
+      expect(vm.playerOrientation, equals(PlayerOrientation.portrait));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AnimatedOpacity wraps chrome
+  // -------------------------------------------------------------------------
+
+  group('chrome animation', () {
+    testWidgets('AnimatedOpacity widgets present for chrome fade',
+        (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2, title: 'My Song'));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      expect(find.byType(AnimatedOpacity), findsAtLeastNWidgets(2));
+    });
+
+    testWidgets('chrome is visible initially', (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2, title: 'Test Song'));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      expect(vm.isChromeVisible, isTrue);
+    });
+
+    testWidgets('tapping screen toggles chrome', (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2, title: 'Test Song'));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+
+      // Chrome starts visible; tap to hide.
+      vm.hideChrome();
+      await tester.pump();
+      expect(vm.isChromeVisible, isFalse);
+
+      // Tap screen to restore.
+      vm.showChrome();
+      await tester.pump();
+      expect(vm.isChromeVisible, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Orientation icon per state
+  // -------------------------------------------------------------------------
+
+  group('orientation icon reflects state', () {
+    testWidgets('portrait orientation shows portrait icon', (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+      await vm.setOrientation(PlayerOrientation.portrait);
+      await tester.pump();
+
+      expect(find.byIcon(Icons.screen_lock_portrait), findsOneWidget);
+    });
+
+    testWidgets('landscape orientation shows landscape icon', (tester) async {
+      notationRepo.setDetail(_makeDetail('n1', 2));
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await _pumpAndLoad(tester, vm);
+      await vm.setOrientation(PlayerOrientation.landscape);
+      await tester.pump();
+
+      expect(find.byIcon(Icons.screen_lock_landscape), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/features/player/notation_player_screen_test.dart
+++ b/test/widget/features/player/notation_player_screen_test.dart
@@ -24,7 +24,9 @@ import 'package:swaralipi/shared/models/notation_draft.dart';
 import 'package:swaralipi/shared/models/notation_page.dart';
 import 'package:swaralipi/shared/models/saved_page.dart';
 import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
 import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -72,6 +74,35 @@ class FakeNotationRepository implements NotationRepository {
       throw UnimplementedError();
 }
 
+class FakePreferencesRepository implements PreferencesRepository {
+  @override
+  Future<UserPreferences> getPreferences() async => const UserPreferences(
+        userName: 'Test',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+      );
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -104,11 +135,7 @@ NotationDetail _makeDetail(String id, int pageCount, {String title = 'Test'}) =>
       customFieldValues: const <CustomFieldValue>[],
     );
 
-Widget _buildScreen(
-  NotationPlayerViewModel vm, {
-  int startPage = 0,
-}) =>
-    MaterialApp(
+Widget _buildScreen(NotationPlayerViewModel vm) => MaterialApp(
       theme: ThemeData(useMaterial3: true),
       home: ChangeNotifierProvider<NotationPlayerViewModel>(
         create: (_) => vm,
@@ -122,9 +149,11 @@ Widget _buildScreen(
 
 void main() {
   late FakeNotationRepository repo;
+  late FakePreferencesRepository prefsRepo;
 
   setUp(() {
     repo = FakeNotationRepository();
+    prefsRepo = FakePreferencesRepository();
   });
 
   // -------------------------------------------------------------------------
@@ -137,7 +166,11 @@ void main() {
       // Use a blocking repo so the load never completes during this test.
       final completer = Completer<NotationDetail?>();
       final blockingRepo = _BlockingFakeRepository(completer.future);
-      final vm = NotationPlayerViewModel(blockingRepo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        blockingRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
       // Pump widget.
       await tester.pumpWidget(_buildScreen(vm));
@@ -156,9 +189,8 @@ void main() {
   });
 
   // Helper: pump widget + process the post-frame callback + await async load.
-  Future<NotationPlayerViewModel> _pumpAndLoad(
+  Future<NotationPlayerViewModel> pumpAndLoad(
     WidgetTester tester,
-    FakeNotationRepository fakeRepo,
     NotationPlayerViewModel vm,
   ) async {
     await tester.pumpWidget(_buildScreen(vm));
@@ -177,9 +209,13 @@ void main() {
     testWidgets('shows not-found message when notation is missing',
         (tester) async {
       repo.setDetail(null);
-      final vm = NotationPlayerViewModel(repo, notationId: 'missing');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'missing',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.textContaining('not found'), findsOneWidget);
     });
@@ -192,9 +228,13 @@ void main() {
   group('error state', () {
     testWidgets('shows error message on load failure', (tester) async {
       repo.setLoadError(Exception('db error'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.textContaining('Error'), findsOneWidget);
     });
@@ -208,18 +248,26 @@ void main() {
     testWidgets('shows page indicator "1 / 3" for 3-page notation',
         (tester) async {
       repo.setDetail(_makeDetail('n1', 3, title: 'My Notation'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.text('1 / 3'), findsOneWidget);
     });
 
     testWidgets('shows notation title in chrome', (tester) async {
       repo.setDetail(_makeDetail('n1', 2, title: 'Raga Yaman'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.text('Raga Yaman'), findsOneWidget);
     });
@@ -227,18 +275,26 @@ void main() {
     testWidgets('shows PageView widget for multi-page notation',
         (tester) async {
       repo.setDetail(_makeDetail('n1', 3));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.byType(PageView), findsOneWidget);
     });
 
     testWidgets('shows InteractiveViewer per page', (tester) async {
       repo.setDetail(_makeDetail('n1', 2));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.byType(InteractiveViewer), findsAtLeastNWidgets(1));
     });
@@ -246,9 +302,13 @@ void main() {
     testWidgets('page indicator updates when goToPage is called',
         (tester) async {
       repo.setDetail(_makeDetail('n1', 3));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       vm.goToPage(1);
       await tester.pump();
@@ -260,11 +320,12 @@ void main() {
       repo.setDetail(_makeDetail('n1', 4));
       final vm = NotationPlayerViewModel(
         repo,
+        preferencesRepository: prefsRepo,
         notationId: 'n1',
         startPage: 1,
       );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       expect(find.text('2 / 4'), findsOneWidget);
     });
@@ -278,9 +339,13 @@ void main() {
     testWidgets('tapping screen toggles chrome via showChrome/hideChrome',
         (tester) async {
       repo.setDetail(_makeDetail('n1', 2, title: 'My Song'));
-      final vm = NotationPlayerViewModel(repo, notationId: 'n1');
+      final vm = NotationPlayerViewModel(
+        repo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
 
-      await _pumpAndLoad(tester, repo, vm);
+      await pumpAndLoad(tester, vm);
 
       // Chrome is initially visible.
       expect(vm.isChromeVisible, isTrue);

--- a/test/widget/features/settings/appearance_screen_test.dart
+++ b/test/widget/features/settings/appearance_screen_test.dart
@@ -79,6 +79,11 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateTagsSeeded({required bool value}) async {
     _prefs = _prefs.copyWith(tagsSeeded: value);
   }
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    _prefs = _prefs.copyWith(playerOrientation: orientation);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +128,9 @@ class _BlockingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
 }
 
 // ---------------------------------------------------------------------------
@@ -316,4 +324,7 @@ class _FailingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
 }


### PR DESCRIPTION
## Linked Issue
Closes #93

## Summary
- Add `PlayerOrientation` enum (auto/portrait/landscape) to `UserPreferences`, persist to new `player_orientation` DB column (schema v4 with migration)
- Add `setOrientation()` / `cycleOrientation()` to `NotationPlayerViewModel`; orientation change persists via `PreferencesRepository.updatePlayerOrientation()`
- Add `_OrientationToggleButton` widget in `_BottomChrome`; icon cycles with orientation state; `SystemChrome.setPreferredOrientations` applied on each build, restored to auto on `dispose()`
- Chrome fade-out constant renamed `kChromeFadeDuration` (3 s, public for tests)

## Type of Change
- [x] feat — new capability
- [x] test — tests only
- [x] chore — build / tooling / deps

## Commit Convention
`feat(player): orientation lock toggle and chrome fade (#93)`

## Test Plan
- [x] Unit tests written — `notation_player_view_model_orientation_test.dart` (9 cases: constant, initial value, setOrientation, cycleOrientation, persistence, listener notify, no-op on same, page swipe preserves orientation)
- [x] Widget tests written — `notation_player_screen_orientation_test.dart` (8 cases: button present, icon per state, tap calls cycleOrientation, AnimatedOpacity present, chrome visible initially, tap toggles chrome, portrait/landscape icon state)
- [x] Existing test fakes updated to supply `preferencesRepository` parameter
- [x] Migration test updated for schema v4
- [x] `flutter test` — 1040 passed, 0 failed
- [x] `flutter analyze` — 0 warnings in touched files
- [x] `dart format` applied

## Screenshots / Recordings
UI change — orientation toggle button appears in bottom chrome alongside page indicator. Icon cycles: `screen_rotation` (auto) → `screen_lock_portrait` → `screen_lock_landscape`.

## Checklist
- [x] No `print` statements
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] Generated files committed (`.g.dart`)
- [x] No hardcoded secrets