### PR TITLE
feat(player): implement auto-scroll at configurable speed with persisted preference (#94)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -413,6 +413,13 @@ class UserPreferencesTable extends Table {
   TextColumn get playerOrientation =>
       text().withDefault(const Constant('auto'))();
 
+  /// Auto-scroll speed multiplier for the notation player.
+  ///
+  /// A REAL value in the range [0.1, 3.0]. Defaults to `1.0` (1× speed).
+  /// Persisted across player sessions so the user's last-used speed is
+  /// restored on the next player open.
+  RealColumn get autoScrollSpeed => real().withDefault(const Constant(1.0))();
+
   @override
   Set<Column> get primaryKey => {id};
 
@@ -430,6 +437,7 @@ class UserPreferencesTable extends Table {
         "CHECK (default_view IN ('list'))",
         'CHECK (tags_seeded IN (0, 1))',
         "CHECK (player_orientation IN ('auto', 'portrait', 'landscape'))",
+        'CHECK (auto_scroll_speed >= 0.1 AND auto_scroll_speed <= 3.0)',
       ];
 }
 
@@ -461,6 +469,7 @@ class UserPreferencesTable extends Table {
 /// | 2 | Add `tags_seeded` column to `user_preferences_table` |
 /// | 3 | Add `deleted_at` column to `instrument_classes_table` |
 /// | 4 | Add `player_orientation` column to `user_preferences_table` |
+/// | 5 | Add `auto_scroll_speed` column to `user_preferences_table` |
 @DriftDatabase(
   tables: [
     NotationsTable,
@@ -529,7 +538,7 @@ class AppDatabase extends _$AppDatabase {
         );
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -562,6 +571,13 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(
               userPreferencesTable,
               userPreferencesTable.playerOrientation,
+            );
+          }
+          // v4 → v5: add auto_scroll_speed column to user_preferences_table.
+          if (from < 5) {
+            await m.addColumn(
+              userPreferencesTable,
+              userPreferencesTable.autoScrollSpeed,
             );
           }
         },

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3462,6 +3462,14 @@ class $UserPreferencesTableTable extends UserPreferencesTable
           type: DriftSqlType.string,
           requiredDuringInsert: false,
           defaultValue: const Constant('auto'));
+  static const VerificationMeta _autoScrollSpeedMeta =
+      const VerificationMeta('autoScrollSpeed');
+  @override
+  late final GeneratedColumn<double> autoScrollSpeed = GeneratedColumn<double>(
+      'auto_scroll_speed', aliasedName, false,
+      type: DriftSqlType.double,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(1.0));
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -3473,6 +3481,7 @@ class $UserPreferencesTableTable extends UserPreferencesTable
         defaultView,
         tagsSeeded,
         playerOrientation,
+        autoScrollSpeed
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3529,6 +3538,12 @@ class $UserPreferencesTableTable extends UserPreferencesTable
           playerOrientation.isAcceptableOrUnknown(
               data['player_orientation']!, _playerOrientationMeta));
     }
+    if (data.containsKey('auto_scroll_speed')) {
+      context.handle(
+          _autoScrollSpeedMeta,
+          autoScrollSpeed.isAcceptableOrUnknown(
+              data['auto_scroll_speed']!, _autoScrollSpeedMeta));
+    }
     return context;
   }
 
@@ -3554,9 +3569,10 @@ class $UserPreferencesTableTable extends UserPreferencesTable
           .read(DriftSqlType.string, data['${effectivePrefix}default_view'])!,
       tagsSeeded: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}tags_seeded'])!,
-      playerOrientation: attachedDatabase.typeMapping.read(DriftSqlType.string,
-              data['${effectivePrefix}player_orientation']) ??
-          'auto',
+      playerOrientation: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}player_orientation'])!,
+      autoScrollSpeed: attachedDatabase.typeMapping.read(
+          DriftSqlType.double, data['${effectivePrefix}auto_scroll_speed'])!,
     );
   }
 
@@ -3600,8 +3616,16 @@ class UserPreferencesRow extends DataClass
 
   /// Preferred screen orientation lock for the notation player.
   ///
-  /// One of `'auto'`, `'portrait'`, or `'landscape'`.
+  /// One of `'auto'`, `'portrait'`, or `'landscape'`. Defaults to `'auto'`
+  /// (sensor-driven, no lock).
   final String playerOrientation;
+
+  /// Auto-scroll speed multiplier for the notation player.
+  ///
+  /// A REAL value in the range [0.1, 3.0]. Defaults to `1.0` (1× speed).
+  /// Persisted across player sessions so the user's last-used speed is
+  /// restored on the next player open.
+  final double autoScrollSpeed;
   const UserPreferencesRow(
       {required this.id,
       required this.userName,
@@ -3611,7 +3635,8 @@ class UserPreferencesRow extends DataClass
       required this.defaultSort,
       required this.defaultView,
       required this.tagsSeeded,
-      this.playerOrientation = 'auto'});
+      required this.playerOrientation,
+      required this.autoScrollSpeed});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3626,6 +3651,7 @@ class UserPreferencesRow extends DataClass
     map['default_view'] = Variable<String>(defaultView);
     map['tags_seeded'] = Variable<int>(tagsSeeded);
     map['player_orientation'] = Variable<String>(playerOrientation);
+    map['auto_scroll_speed'] = Variable<double>(autoScrollSpeed);
     return map;
   }
 
@@ -3642,6 +3668,7 @@ class UserPreferencesRow extends DataClass
       defaultView: Value(defaultView),
       tagsSeeded: Value(tagsSeeded),
       playerOrientation: Value(playerOrientation),
+      autoScrollSpeed: Value(autoScrollSpeed),
     );
   }
 
@@ -3657,8 +3684,8 @@ class UserPreferencesRow extends DataClass
       defaultSort: serializer.fromJson<String>(json['defaultSort']),
       defaultView: serializer.fromJson<String>(json['defaultView']),
       tagsSeeded: serializer.fromJson<int>(json['tagsSeeded']),
-      playerOrientation:
-          serializer.fromJson<String>(json['playerOrientation'] ?? 'auto'),
+      playerOrientation: serializer.fromJson<String>(json['playerOrientation']),
+      autoScrollSpeed: serializer.fromJson<double>(json['autoScrollSpeed']),
     );
   }
   @override
@@ -3674,6 +3701,7 @@ class UserPreferencesRow extends DataClass
       'defaultView': serializer.toJson<String>(defaultView),
       'tagsSeeded': serializer.toJson<int>(tagsSeeded),
       'playerOrientation': serializer.toJson<String>(playerOrientation),
+      'autoScrollSpeed': serializer.toJson<double>(autoScrollSpeed),
     };
   }
 
@@ -3686,7 +3714,8 @@ class UserPreferencesRow extends DataClass
           String? defaultSort,
           String? defaultView,
           int? tagsSeeded,
-          String? playerOrientation}) =>
+          String? playerOrientation,
+          double? autoScrollSpeed}) =>
       UserPreferencesRow(
         id: id ?? this.id,
         userName: userName ?? this.userName,
@@ -3697,6 +3726,7 @@ class UserPreferencesRow extends DataClass
         defaultView: defaultView ?? this.defaultView,
         tagsSeeded: tagsSeeded ?? this.tagsSeeded,
         playerOrientation: playerOrientation ?? this.playerOrientation,
+        autoScrollSpeed: autoScrollSpeed ?? this.autoScrollSpeed,
       );
   UserPreferencesRow copyWithCompanion(UserPreferencesTableCompanion data) {
     return UserPreferencesRow(
@@ -3716,6 +3746,9 @@ class UserPreferencesRow extends DataClass
       playerOrientation: data.playerOrientation.present
           ? data.playerOrientation.value
           : this.playerOrientation,
+      autoScrollSpeed: data.autoScrollSpeed.present
+          ? data.autoScrollSpeed.value
+          : this.autoScrollSpeed,
     );
   }
 
@@ -3730,14 +3763,24 @@ class UserPreferencesRow extends DataClass
           ..write('defaultSort: $defaultSort, ')
           ..write('defaultView: $defaultView, ')
           ..write('tagsSeeded: $tagsSeeded, ')
-          ..write('playerOrientation: $playerOrientation')
+          ..write('playerOrientation: $playerOrientation, ')
+          ..write('autoScrollSpeed: $autoScrollSpeed')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, userName, themeMode, colorSchemeMode,
-      seedColor, defaultSort, defaultView, tagsSeeded, playerOrientation);
+  int get hashCode => Object.hash(
+      id,
+      userName,
+      themeMode,
+      colorSchemeMode,
+      seedColor,
+      defaultSort,
+      defaultView,
+      tagsSeeded,
+      playerOrientation,
+      autoScrollSpeed);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3750,7 +3793,8 @@ class UserPreferencesRow extends DataClass
           other.defaultSort == this.defaultSort &&
           other.defaultView == this.defaultView &&
           other.tagsSeeded == this.tagsSeeded &&
-          other.playerOrientation == this.playerOrientation);
+          other.playerOrientation == this.playerOrientation &&
+          other.autoScrollSpeed == this.autoScrollSpeed);
 }
 
 class UserPreferencesTableCompanion
@@ -3764,6 +3808,7 @@ class UserPreferencesTableCompanion
   final Value<String> defaultView;
   final Value<int> tagsSeeded;
   final Value<String> playerOrientation;
+  final Value<double> autoScrollSpeed;
   const UserPreferencesTableCompanion({
     this.id = const Value.absent(),
     this.userName = const Value.absent(),
@@ -3774,6 +3819,7 @@ class UserPreferencesTableCompanion
     this.defaultView = const Value.absent(),
     this.tagsSeeded = const Value.absent(),
     this.playerOrientation = const Value.absent(),
+    this.autoScrollSpeed = const Value.absent(),
   });
   UserPreferencesTableCompanion.insert({
     this.id = const Value.absent(),
@@ -3785,6 +3831,7 @@ class UserPreferencesTableCompanion
     this.defaultView = const Value.absent(),
     this.tagsSeeded = const Value.absent(),
     this.playerOrientation = const Value.absent(),
+    this.autoScrollSpeed = const Value.absent(),
   });
   static Insertable<UserPreferencesRow> custom({
     Expression<int>? id,
@@ -3796,6 +3843,7 @@ class UserPreferencesTableCompanion
     Expression<String>? defaultView,
     Expression<int>? tagsSeeded,
     Expression<String>? playerOrientation,
+    Expression<double>? autoScrollSpeed,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -3807,6 +3855,7 @@ class UserPreferencesTableCompanion
       if (defaultView != null) 'default_view': defaultView,
       if (tagsSeeded != null) 'tags_seeded': tagsSeeded,
       if (playerOrientation != null) 'player_orientation': playerOrientation,
+      if (autoScrollSpeed != null) 'auto_scroll_speed': autoScrollSpeed,
     });
   }
 
@@ -3819,7 +3868,8 @@ class UserPreferencesTableCompanion
       Value<String>? defaultSort,
       Value<String>? defaultView,
       Value<int>? tagsSeeded,
-      Value<String>? playerOrientation}) {
+      Value<String>? playerOrientation,
+      Value<double>? autoScrollSpeed}) {
     return UserPreferencesTableCompanion(
       id: id ?? this.id,
       userName: userName ?? this.userName,
@@ -3830,6 +3880,7 @@ class UserPreferencesTableCompanion
       defaultView: defaultView ?? this.defaultView,
       tagsSeeded: tagsSeeded ?? this.tagsSeeded,
       playerOrientation: playerOrientation ?? this.playerOrientation,
+      autoScrollSpeed: autoScrollSpeed ?? this.autoScrollSpeed,
     );
   }
 
@@ -3863,6 +3914,9 @@ class UserPreferencesTableCompanion
     if (playerOrientation.present) {
       map['player_orientation'] = Variable<String>(playerOrientation.value);
     }
+    if (autoScrollSpeed.present) {
+      map['auto_scroll_speed'] = Variable<double>(autoScrollSpeed.value);
+    }
     return map;
   }
 
@@ -3877,7 +3931,8 @@ class UserPreferencesTableCompanion
           ..write('defaultSort: $defaultSort, ')
           ..write('defaultView: $defaultView, ')
           ..write('tagsSeeded: $tagsSeeded, ')
-          ..write('playerOrientation: $playerOrientation')
+          ..write('playerOrientation: $playerOrientation, ')
+          ..write('autoScrollSpeed: $autoScrollSpeed')
           ..write(')'))
         .toString();
   }
@@ -7234,6 +7289,8 @@ typedef $$UserPreferencesTableTableCreateCompanionBuilder
   Value<String> defaultSort,
   Value<String> defaultView,
   Value<int> tagsSeeded,
+  Value<String> playerOrientation,
+  Value<double> autoScrollSpeed,
 });
 typedef $$UserPreferencesTableTableUpdateCompanionBuilder
     = UserPreferencesTableCompanion Function({
@@ -7245,6 +7302,8 @@ typedef $$UserPreferencesTableTableUpdateCompanionBuilder
   Value<String> defaultSort,
   Value<String> defaultView,
   Value<int> tagsSeeded,
+  Value<String> playerOrientation,
+  Value<double> autoScrollSpeed,
 });
 
 class $$UserPreferencesTableTableFilterComposer
@@ -7280,6 +7339,14 @@ class $$UserPreferencesTableTableFilterComposer
 
   ColumnFilters<int> get tagsSeeded => $composableBuilder(
       column: $table.tagsSeeded, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get playerOrientation => $composableBuilder(
+      column: $table.playerOrientation,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get autoScrollSpeed => $composableBuilder(
+      column: $table.autoScrollSpeed,
+      builder: (column) => ColumnFilters(column));
 }
 
 class $$UserPreferencesTableTableOrderingComposer
@@ -7315,6 +7382,14 @@ class $$UserPreferencesTableTableOrderingComposer
 
   ColumnOrderings<int> get tagsSeeded => $composableBuilder(
       column: $table.tagsSeeded, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get playerOrientation => $composableBuilder(
+      column: $table.playerOrientation,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get autoScrollSpeed => $composableBuilder(
+      column: $table.autoScrollSpeed,
+      builder: (column) => ColumnOrderings(column));
 }
 
 class $$UserPreferencesTableTableAnnotationComposer
@@ -7349,6 +7424,12 @@ class $$UserPreferencesTableTableAnnotationComposer
 
   GeneratedColumn<int> get tagsSeeded => $composableBuilder(
       column: $table.tagsSeeded, builder: (column) => column);
+
+  GeneratedColumn<String> get playerOrientation => $composableBuilder(
+      column: $table.playerOrientation, builder: (column) => column);
+
+  GeneratedColumn<double> get autoScrollSpeed => $composableBuilder(
+      column: $table.autoScrollSpeed, builder: (column) => column);
 }
 
 class $$UserPreferencesTableTableTableManager extends RootTableManager<
@@ -7389,6 +7470,8 @@ class $$UserPreferencesTableTableTableManager extends RootTableManager<
             Value<String> defaultSort = const Value.absent(),
             Value<String> defaultView = const Value.absent(),
             Value<int> tagsSeeded = const Value.absent(),
+            Value<String> playerOrientation = const Value.absent(),
+            Value<double> autoScrollSpeed = const Value.absent(),
           }) =>
               UserPreferencesTableCompanion(
             id: id,
@@ -7399,6 +7482,8 @@ class $$UserPreferencesTableTableTableManager extends RootTableManager<
             defaultSort: defaultSort,
             defaultView: defaultView,
             tagsSeeded: tagsSeeded,
+            playerOrientation: playerOrientation,
+            autoScrollSpeed: autoScrollSpeed,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -7409,6 +7494,8 @@ class $$UserPreferencesTableTableTableManager extends RootTableManager<
             Value<String> defaultSort = const Value.absent(),
             Value<String> defaultView = const Value.absent(),
             Value<int> tagsSeeded = const Value.absent(),
+            Value<String> playerOrientation = const Value.absent(),
+            Value<double> autoScrollSpeed = const Value.absent(),
           }) =>
               UserPreferencesTableCompanion.insert(
             id: id,
@@ -7419,6 +7506,8 @@ class $$UserPreferencesTableTableTableManager extends RootTableManager<
             defaultSort: defaultSort,
             defaultView: defaultView,
             tagsSeeded: tagsSeeded,
+            playerOrientation: playerOrientation,
+            autoScrollSpeed: autoScrollSpeed,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/lib/features/notation_detail/screens/notation_detail_screen.dart
+++ b/lib/features/notation_detail/screens/notation_detail_screen.dart
@@ -611,4 +611,7 @@ final class _NoOpPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
 }

--- a/lib/features/player/screens/notation_player_screen.dart
+++ b/lib/features/player/screens/notation_player_screen.dart
@@ -12,6 +12,8 @@
 //     Non-destructive rendering is handled by the Page Editor flow.
 //   - Title + page indicator fade in/out (chrome) on tap after 3 s idle.
 //   - Orientation lock toggle (auto / portrait / landscape) in bottom chrome.
+//   - Auto-scroll toggle + speed slider shown in bottom chrome when enabled.
+//   - Timer.periodic drives smooth scroll; pauses on swipe gesture.
 //   - Back navigation returns to the previous screen.
 //
 // The screen reads [NotationPlayerViewModel] from a [ChangeNotifierProvider]
@@ -55,6 +57,12 @@ const double _kMinScale = 0.5;
 /// Maximum scale for [InteractiveViewer] pinch-zoom.
 const double _kMaxScale = 5.0;
 
+/// Slider step increment for the auto-scroll speed control.
+const double _kSpeedSliderStep = 0.1;
+
+/// Scroll animation duration per tick — short for smoothness.
+const Duration _kScrollAnimationDuration = Duration(milliseconds: 80);
+
 // ---------------------------------------------------------------------------
 // Screen
 // ---------------------------------------------------------------------------
@@ -74,32 +82,60 @@ class NotationPlayerScreen extends StatefulWidget {
 class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
   late PageController _pageController;
   Timer? _chromeFadeTimer;
+  Timer? _autoScrollTimer;
+
+  /// Whether a swipe gesture is currently active (suppresses auto-scroll tick).
+  bool _isSwiping = false;
+
+  /// Cached reference to the ViewModel so we can remove the listener in
+  /// [dispose] without needing [BuildContext] after unmount.
+  late NotationPlayerViewModel _vm;
 
   @override
   void initState() {
     super.initState();
-    final vm = context.read<NotationPlayerViewModel>();
-    _pageController = PageController(initialPage: vm.currentPage);
+    _vm = context.read<NotationPlayerViewModel>();
+    _pageController = PageController(initialPage: _vm.currentPage);
+    // Listen to ViewModel to sync the auto-scroll timer outside build().
+    _vm.addListener(_onViewModelChanged);
     // Defer load to after the first frame to avoid notifyListeners during build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _load();
     });
   }
 
-  Future<void> _load() async {
-    final vm = context.read<NotationPlayerViewModel>();
-    await vm.loadNotation();
+  /// Responds to ViewModel changes to keep the auto-scroll timer in sync.
+  ///
+  /// Runs outside [build] so Timer management is a side-effect-free listener.
+  void _onViewModelChanged() {
     if (!mounted) return;
-    final vmAfterLoad = context.read<NotationPlayerViewModel>();
+    if (_vm.autoScrollEnabled) {
+      if (_autoScrollTimer == null || !_autoScrollTimer!.isActive) {
+        _startAutoScrollTimer(_vm);
+      }
+    } else {
+      if (_autoScrollTimer != null && _autoScrollTimer!.isActive) {
+        _cancelAutoScrollTimer();
+      }
+    }
+  }
+
+  Future<void> _load() async {
+    await _vm.loadNotation();
+    if (!mounted) return;
+    // Load the persisted speed preference so the slider starts at the last
+    // used value.
+    await _vm.loadPersistedSpeed();
+    if (!mounted) return;
     // Sync PageController only when it is attached to a PageView and the
     // current page differs from the controller's page.
-    if (vmAfterLoad.pageCount > 0 &&
+    if (_vm.pageCount > 0 &&
         _pageController.hasClients &&
-        _pageController.page?.round() != vmAfterLoad.currentPage) {
-      _pageController.jumpToPage(vmAfterLoad.currentPage);
+        _pageController.page?.round() != _vm.currentPage) {
+      _pageController.jumpToPage(_vm.currentPage);
     }
     // Start the chrome fade timer only after load completes successfully.
-    if (vmAfterLoad.state is NotationPlayerStateSuccess) {
+    if (_vm.state is NotationPlayerStateSuccess) {
       _scheduleFade();
     }
   }
@@ -108,24 +144,96 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
     _chromeFadeTimer?.cancel();
     _chromeFadeTimer = Timer(kChromeFadeDuration, () {
       if (!mounted) return;
-      context.read<NotationPlayerViewModel>().hideChrome();
+      _vm.hideChrome();
     });
   }
 
   void _onTapScreen() {
-    final vm = context.read<NotationPlayerViewModel>();
-    if (vm.isChromeVisible) {
-      vm.hideChrome();
+    if (_vm.isChromeVisible) {
+      _vm.hideChrome();
       _chromeFadeTimer?.cancel();
     } else {
-      vm.showChrome();
+      _vm.showChrome();
       _scheduleFade();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auto-scroll
+  // ---------------------------------------------------------------------------
+
+  /// Starts or restarts the [Timer.periodic] that drives smooth auto-scroll.
+  void _startAutoScrollTimer(NotationPlayerViewModel vm) {
+    _autoScrollTimer?.cancel();
+    _autoScrollTimer = Timer.periodic(
+      const Duration(milliseconds: kAutoScrollTickIntervalMs),
+      (_) => _onAutoScrollTick(),
+    );
+  }
+
+  /// Cancels the auto-scroll timer without changing ViewModel state.
+  void _cancelAutoScrollTimer() {
+    _autoScrollTimer?.cancel();
+    _autoScrollTimer = null;
+  }
+
+  /// Advances the scroll position by one step on each timer tick.
+  ///
+  /// Skips the tick when a swipe is in progress or the controller has no
+  /// clients. Stops auto-scroll when the end of the content is reached.
+  void _onAutoScrollTick() {
+    if (!mounted || _isSwiping) return;
+    if (!_pageController.hasClients) return;
+
+    final position = _pageController.position;
+    final viewportHeight = position.viewportDimension;
+    final step = NotationPlayerViewModel.calculateScrollStep(
+      speed: _vm.autoScrollSpeed,
+      viewportHeight: viewportHeight,
+      tickIntervalMs: kAutoScrollTickIntervalMs,
+    );
+
+    final currentOffset = position.pixels;
+    final maxOffset = position.maxScrollExtent;
+
+    if (currentOffset >= maxOffset) {
+      // Reached the end — stop auto-scroll.
+      _vm.stopAutoScroll();
+      _cancelAutoScrollTimer();
+      return;
+    }
+
+    final targetOffset = (currentOffset + step).clamp(0.0, maxOffset);
+    _pageController.animateTo(
+      targetOffset,
+      duration: _kScrollAnimationDuration,
+      curve: Curves.linear,
+    );
+  }
+
+  /// Called when the user starts a drag/swipe gesture.
+  void _onScrollStart() {
+    _isSwiping = true;
+    // Pause auto-scroll while swiping.
+    if (_vm.autoScrollEnabled) {
+      _cancelAutoScrollTimer();
+    }
+  }
+
+  /// Called when the user ends a drag/swipe gesture.
+  void _onScrollEnd() {
+    _isSwiping = false;
+    // Resume auto-scroll if still enabled after the swipe.
+    if (_vm.autoScrollEnabled) {
+      _startAutoScrollTimer(_vm);
     }
   }
 
   @override
   void dispose() {
+    _vm.removeListener(_onViewModelChanged);
     _chromeFadeTimer?.cancel();
+    _autoScrollTimer?.cancel();
     _pageController.dispose();
     // Restore auto-rotate when leaving the player.
     SystemChrome.setPreferredOrientations([]);
@@ -154,6 +262,8 @@ class _NotationPlayerScreenState extends State<NotationPlayerScreen> {
             vm: vm,
             pageController: _pageController,
             onTap: _onTapScreen,
+            onScrollStart: _onScrollStart,
+            onScrollEnd: _onScrollEnd,
           ),
       },
     );
@@ -289,12 +399,16 @@ class _PlayerView extends StatelessWidget {
     required this.vm,
     required this.pageController,
     required this.onTap,
+    required this.onScrollStart,
+    required this.onScrollEnd,
   });
 
   final NotationDetail detail;
   final NotationPlayerViewModel vm;
   final PageController pageController;
   final VoidCallback onTap;
+  final VoidCallback onScrollStart;
+  final VoidCallback onScrollEnd;
 
   @override
   Widget build(BuildContext context) {
@@ -302,16 +416,28 @@ class _PlayerView extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
+      onPanStart: (_) => onScrollStart(),
+      onPanEnd: (_) => onScrollEnd(),
       behavior: HitTestBehavior.opaque,
       child: Stack(
         children: [
-          // Page content.
-          PageView.builder(
-            controller: pageController,
-            itemCount: pageCount,
-            onPageChanged: (index) => vm.goToPage(index),
-            itemBuilder: (context, index) => _PageView(
-              page: detail.pages[index],
+          // Page content — NotificationListener detects page swipe start/end.
+          NotificationListener<ScrollNotification>(
+            onNotification: (notification) {
+              if (notification is ScrollStartNotification) {
+                onScrollStart();
+              } else if (notification is ScrollEndNotification) {
+                onScrollEnd();
+              }
+              return false;
+            },
+            child: PageView.builder(
+              controller: pageController,
+              itemCount: pageCount,
+              onPageChanged: (index) => vm.goToPage(index),
+              itemBuilder: (context, index) => _PageView(
+                page: detail.pages[index],
+              ),
             ),
           ),
 
@@ -328,6 +454,11 @@ class _PlayerView extends StatelessWidget {
             isVisible: vm.isChromeVisible,
             playerOrientation: vm.playerOrientation,
             onOrientationToggle: vm.cycleOrientation,
+            autoScrollEnabled: vm.autoScrollEnabled,
+            autoScrollSpeed: vm.autoScrollSpeed,
+            onAutoScrollToggle: vm.toggleAutoScroll,
+            onSpeedChanged: vm.updateScrollSpeedLocal,
+            onSpeedChangeEnd: vm.setScrollSpeed,
           ),
         ],
       ),
@@ -488,7 +619,8 @@ class _TitleChrome extends StatelessWidget {
 // Bottom chrome (page indicator + orientation toggle)
 // ---------------------------------------------------------------------------
 
-/// Animated bottom bar showing the page indicator and orientation toggle.
+/// Animated bottom bar showing the page indicator, orientation toggle,
+/// auto-scroll toggle, and (when enabled) the speed slider.
 class _BottomChrome extends StatelessWidget {
   const _BottomChrome({
     required this.currentPage,
@@ -496,6 +628,11 @@ class _BottomChrome extends StatelessWidget {
     required this.isVisible,
     required this.playerOrientation,
     required this.onOrientationToggle,
+    required this.autoScrollEnabled,
+    required this.autoScrollSpeed,
+    required this.onAutoScrollToggle,
+    required this.onSpeedChanged,
+    required this.onSpeedChangeEnd,
   });
 
   final int currentPage;
@@ -503,6 +640,15 @@ class _BottomChrome extends StatelessWidget {
   final bool isVisible;
   final PlayerOrientation playerOrientation;
   final VoidCallback onOrientationToggle;
+  final bool autoScrollEnabled;
+  final double autoScrollSpeed;
+  final VoidCallback onAutoScrollToggle;
+
+  /// Updates speed in-memory on every drag frame (no DB write).
+  final void Function(double) onSpeedChanged;
+
+  /// Persists speed to storage once drag ends.
+  final Future<void> Function(double) onSpeedChangeEnd;
 
   @override
   Widget build(BuildContext context) {
@@ -513,36 +659,63 @@ class _BottomChrome extends StatelessWidget {
       child: AnimatedOpacity(
         duration: _kChromeAnimationDuration,
         opacity: isVisible ? 1.0 : 0.0,
-        child: Container(
-          decoration: const BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.bottomCenter,
-              end: Alignment.topCenter,
-              colors: [Colors.black87, Colors.transparent],
+        child: IgnorePointer(
+          ignoring: !isVisible,
+          child: Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [Colors.black87, Colors.transparent],
+              ),
             ),
-          ),
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: SafeArea(
-            top: false,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Semantics(
-                  label: 'Page ${currentPage + 1} of $pageCount',
-                  child: Text(
-                    '${currentPage + 1} / $pageCount',
-                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                          color: Colors.white,
-                          letterSpacing: 1.5,
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: SafeArea(
+              top: false,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Speed slider — only shown when auto-scroll is enabled.
+                  if (autoScrollEnabled)
+                    _AutoScrollSpeedPanel(
+                      speed: autoScrollSpeed,
+                      onSpeedChanged: onSpeedChanged,
+                      onSpeedChangeEnd: onSpeedChangeEnd,
+                    ),
+                  // Controls row: page indicator, auto-scroll toggle, orient.
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Semantics(
+                          label: 'Page ${currentPage + 1} of $pageCount',
+                          child: Text(
+                            '${currentPage + 1} / $pageCount',
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelLarge
+                                ?.copyWith(
+                                  color: Colors.white,
+                                  letterSpacing: 1.5,
+                                ),
+                          ),
                         ),
+                        const SizedBox(width: 16),
+                        _AutoScrollToggleButton(
+                          enabled: autoScrollEnabled,
+                          onTap: onAutoScrollToggle,
+                        ),
+                        const SizedBox(width: 8),
+                        _OrientationToggleButton(
+                          orientation: playerOrientation,
+                          onTap: onOrientationToggle,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                const SizedBox(width: 24),
-                _OrientationToggleButton(
-                  orientation: playerOrientation,
-                  onTap: onOrientationToggle,
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
@@ -590,6 +763,121 @@ class _OrientationToggleButton extends StatelessWidget {
         onPressed: onTap,
         icon: Icon(icon, color: Colors.white),
         tooltip: label,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-scroll toggle button
+// ---------------------------------------------------------------------------
+
+/// Icon button that toggles the auto-scroll feature on or off.
+///
+/// Displays a filled play icon when enabled, outlined when disabled.
+class _AutoScrollToggleButton extends StatelessWidget {
+  const _AutoScrollToggleButton({
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = enabled ? 'Auto-scroll: on' : 'Auto-scroll: off';
+    final icon = enabled ? Icons.play_circle : Icons.play_circle_outline;
+
+    return Semantics(
+      label: label,
+      button: true,
+      toggled: enabled,
+      child: IconButton(
+        key: const Key('auto_scroll_toggle_button'),
+        onPressed: onTap,
+        icon: Icon(icon, color: Colors.white),
+        tooltip: label,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-scroll speed panel
+// ---------------------------------------------------------------------------
+
+/// A horizontal row containing the speed label and slider for auto-scroll.
+///
+/// Shown in the bottom chrome when auto-scroll is enabled. The slider range
+/// mirrors [kMinAutoScrollSpeed]–[kMaxAutoScrollSpeed] with [_kSpeedSliderStep]
+/// divisions.
+///
+/// [onSpeedChanged] is called on every drag frame to update the in-memory speed
+/// immediately. [onSpeedChangeEnd] is called once when the drag ends to persist
+/// the final value, avoiding a DB write per drag frame.
+class _AutoScrollSpeedPanel extends StatelessWidget {
+  const _AutoScrollSpeedPanel({
+    required this.speed,
+    required this.onSpeedChanged,
+    required this.onSpeedChangeEnd,
+  });
+
+  final double speed;
+
+  /// Called on every slider drag frame — updates in-memory speed immediately.
+  final void Function(double) onSpeedChanged;
+
+  /// Called once when drag ends — persists the final speed to storage.
+  final Future<void> Function(double) onSpeedChangeEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final divisions =
+        ((kMaxAutoScrollSpeed - kMinAutoScrollSpeed) / _kSpeedSliderStep)
+            .round();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Row(
+        children: [
+          const Icon(Icons.speed, color: Colors.white, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Semantics(
+              label: 'Auto-scroll speed: ${speed.toStringAsFixed(1)}×',
+              slider: true,
+              child: SliderTheme(
+                data: SliderTheme.of(context).copyWith(
+                  activeTrackColor: Colors.white,
+                  inactiveTrackColor: Colors.white30,
+                  thumbColor: Colors.white,
+                  overlayColor: Colors.white24,
+                  valueIndicatorColor: Colors.white,
+                  valueIndicatorTextStyle: const TextStyle(
+                    color: Colors.black,
+                  ),
+                ),
+                child: Slider(
+                  key: const Key('auto_scroll_speed_slider'),
+                  value: speed,
+                  min: kMinAutoScrollSpeed,
+                  max: kMaxAutoScrollSpeed,
+                  divisions: divisions,
+                  label: '${speed.toStringAsFixed(1)}×',
+                  onChanged: onSpeedChanged,
+                  onChangeEnd: (v) => onSpeedChangeEnd(v),
+                ),
+              ),
+            ),
+          ),
+          Text(
+            '${speed.toStringAsFixed(1)}×',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Colors.white,
+                ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/player/viewmodels/notation_player_view_model.dart
+++ b/lib/features/player/viewmodels/notation_player_view_model.dart
@@ -4,8 +4,8 @@
 // play-count on successful load via [NotationRepository.updatePlayCount], and
 // exposes state as a sealed [NotationPlayerState] hierarchy.
 //
-// Also tracks the active page index, chrome-visibility flag, and
-// player-orientation lock used by [NotationPlayerScreen].
+// Also tracks the active page index, chrome-visibility flag, player-
+// orientation lock, and auto-scroll state used by [NotationPlayerScreen].
 //
 // Construction:
 //   NotationPlayerViewModel(
@@ -17,6 +17,7 @@
 //
 // Lifecycle:
 //   Call [loadNotation] once per navigation to the player screen.
+//   Call [loadPersistedSpeed] after [loadNotation] to restore the saved speed.
 //   Call [dispose] when the screen is removed from the tree (ChangeNotifier
 //   lifecycle handles this automatically when used with ChangeNotifierProvider).
 
@@ -30,7 +31,7 @@ import 'package:swaralipi/shared/repositories/notation_repository.dart';
 import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 
 // ---------------------------------------------------------------------------
-// Public constant
+// Public constants
 // ---------------------------------------------------------------------------
 
 /// Duration after which the chrome (title + toolbar) fades out.
@@ -38,6 +39,29 @@ import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 /// Exposed as a top-level constant so widget tests can assert on it
 /// without needing access to private state.
 const Duration kChromeFadeDuration = Duration(seconds: 3);
+
+/// Default auto-scroll speed multiplier.
+///
+/// Applied on first use and after factory reset of preferences.
+const double kDefaultAutoScrollSpeed = 1.0;
+
+/// Minimum auto-scroll speed multiplier (0.1×).
+const double kMinAutoScrollSpeed = 0.1;
+
+/// Maximum auto-scroll speed multiplier (3.0×).
+const double kMaxAutoScrollSpeed = 3.0;
+
+/// Tick interval for the auto-scroll [Timer.periodic] in milliseconds.
+///
+/// A 50 ms tick gives 20 updates per second — smooth enough for reading
+/// without excessive battery drain.
+const int kAutoScrollTickIntervalMs = 50;
+
+/// The fraction of the viewport height scrolled per second at 1× speed.
+///
+/// At speed 1.0 and a viewport height of 800 px, the content scrolls at
+/// `800 × kScrollViewportFractionPerSecond = 80` px/s.
+const double kScrollViewportFractionPerSecond = 0.1;
 
 // ---------------------------------------------------------------------------
 // State hierarchy
@@ -136,6 +160,8 @@ class NotationPlayerViewModel extends ChangeNotifier {
   int _currentPage;
   bool _isChromeVisible = true;
   PlayerOrientation _playerOrientation = PlayerOrientation.auto;
+  bool _autoScrollEnabled = false;
+  double _autoScrollSpeed = kDefaultAutoScrollSpeed;
 
   // -------------------------------------------------------------------------
   // Public getters
@@ -164,6 +190,14 @@ class NotationPlayerViewModel extends ChangeNotifier {
         NotationPlayerStateSuccess(:final detail) => detail.pages.length,
         _ => 0,
       };
+
+  /// Whether auto-scroll is currently active.
+  bool get autoScrollEnabled => _autoScrollEnabled;
+
+  /// The current auto-scroll speed multiplier.
+  ///
+  /// Always in the range [[kMinAutoScrollSpeed], [kMaxAutoScrollSpeed]].
+  double get autoScrollSpeed => _autoScrollSpeed;
 
   // -------------------------------------------------------------------------
   // Load
@@ -289,5 +323,116 @@ class NotationPlayerViewModel extends ChangeNotifier {
       PlayerOrientation.landscape => PlayerOrientation.auto,
     };
     await setOrientation(next);
+  }
+
+  // -------------------------------------------------------------------------
+  // Auto-scroll
+  // -------------------------------------------------------------------------
+
+  /// Toggles the auto-scroll feature on or off and notifies listeners.
+  ///
+  /// When enabled, the screen layer is responsible for starting the scroll
+  /// timer. When disabled, the timer should be cancelled.
+  void toggleAutoScroll() {
+    _autoScrollEnabled = !_autoScrollEnabled;
+    notifyListeners();
+  }
+
+  /// Disables auto-scroll and notifies listeners.
+  ///
+  /// Does nothing (no notification) when auto-scroll is already disabled.
+  /// Called by the screen when a swipe gesture is detected.
+  void stopAutoScroll() {
+    if (!_autoScrollEnabled) return;
+    _autoScrollEnabled = false;
+    notifyListeners();
+  }
+
+  /// Updates the in-memory auto-scroll speed to [speed] without persisting.
+  ///
+  /// Intended for use during continuous slider drag so the ViewModel notifies
+  /// on every frame without triggering a DB write. Call [setScrollSpeed] on
+  /// drag end to persist the final value.
+  ///
+  /// The speed is clamped to [[kMinAutoScrollSpeed], [kMaxAutoScrollSpeed]].
+  /// Does nothing (no notification) when the clamped value equals the current
+  /// speed.
+  ///
+  /// Parameters:
+  /// - [speed]: The desired speed multiplier before clamping.
+  void updateScrollSpeedLocal(double speed) {
+    final clamped = speed.clamp(kMinAutoScrollSpeed, kMaxAutoScrollSpeed);
+    if (clamped == _autoScrollSpeed) return;
+    _autoScrollSpeed = clamped;
+    notifyListeners();
+  }
+
+  /// Sets the auto-scroll speed to [speed], clamped to
+  /// [[kMinAutoScrollSpeed], [kMaxAutoScrollSpeed]], and persists the value.
+  ///
+  /// Does nothing (no notification) when the clamped value equals the
+  /// current speed.
+  ///
+  /// Parameters:
+  /// - [speed]: The desired speed multiplier before clamping.
+  Future<void> setScrollSpeed(double speed) async {
+    final clamped = speed.clamp(kMinAutoScrollSpeed, kMaxAutoScrollSpeed);
+    if (clamped == _autoScrollSpeed) return;
+    _autoScrollSpeed = clamped;
+    notifyListeners();
+    try {
+      await _preferencesRepository.updateAutoScrollSpeed(clamped);
+    } on Exception catch (e, st) {
+      log(
+        'NotationPlayerViewModel: updateAutoScrollSpeed failed — $e',
+        name: 'NotationPlayerViewModel',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
+  /// Loads the persisted auto-scroll speed from [PreferencesRepository] and
+  /// applies it, notifying listeners.
+  ///
+  /// Should be called once after [loadNotation] completes. Failures are
+  /// logged and silently ignored (the default speed is retained).
+  Future<void> loadPersistedSpeed() async {
+    try {
+      final prefs = await _preferencesRepository.getPreferences();
+      final clamped =
+          prefs.autoScrollSpeed.clamp(kMinAutoScrollSpeed, kMaxAutoScrollSpeed);
+      _autoScrollSpeed = clamped;
+      notifyListeners();
+    } on Exception catch (e, st) {
+      log(
+        'NotationPlayerViewModel: loadPersistedSpeed failed — $e',
+        name: 'NotationPlayerViewModel',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
+  /// Calculates the number of pixels to scroll per timer tick.
+  ///
+  /// The step is derived from [viewportHeight], [speed], and the
+  /// [tickIntervalMs] so that at 1× speed the viewport scrolls at
+  /// [kScrollViewportFractionPerSecond] of its height per second.
+  ///
+  /// Returns the computed pixel step as a [double].
+  ///
+  /// Parameters:
+  /// - [speed]: Auto-scroll speed multiplier.
+  /// - [viewportHeight]: The visible height of the scroll area in logical pixels.
+  /// - [tickIntervalMs]: Timer tick interval in milliseconds.
+  static double calculateScrollStep({
+    required double speed,
+    required double viewportHeight,
+    required int tickIntervalMs,
+  }) {
+    final pixelsPerSecond =
+        viewportHeight * kScrollViewportFractionPerSecond * speed;
+    return pixelsPerSecond * tickIntervalMs / 1000.0;
   }
 }

--- a/lib/features/settings/data/user_preferences_repository_impl.dart
+++ b/lib/features/settings/data/user_preferences_repository_impl.dart
@@ -71,6 +71,7 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
         defaultView: Value(preferences.defaultView.dbValue),
         tagsSeeded: Value(preferences.tagsSeeded ? 1 : 0),
         playerOrientation: Value(preferences.playerOrientation.dbValue),
+        autoScrollSpeed: Value(preferences.autoScrollSpeed),
       ),
     );
     log(
@@ -166,6 +167,29 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
   }
 
   @override
+  Future<void> updateAutoScrollSpeed(double speed) async {
+    final existing = await _dao.getPreferences();
+    await _dao.upsertPreferences(
+      UserPreferencesTableCompanion(
+        id: const Value(_kSingletonId),
+        userName: Value(existing.userName),
+        themeMode: Value(existing.themeMode),
+        colorSchemeMode: Value(existing.colorSchemeMode),
+        seedColor: Value(existing.seedColor),
+        defaultSort: Value(existing.defaultSort),
+        defaultView: Value(existing.defaultView),
+        tagsSeeded: Value(existing.tagsSeeded),
+        playerOrientation: Value(existing.playerOrientation),
+        autoScrollSpeed: Value(speed.clamp(0.1, 3.0)),
+      ),
+    );
+    log(
+      'UserPreferencesRepositoryImpl: autoScrollSpeed set to $speed',
+      name: 'UserPreferencesRepository',
+    );
+  }
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {
     final existing = await _dao.getPreferences();
     await _dao.upsertPreferences(
@@ -223,6 +247,7 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
       defaultView: defaultView,
       tagsSeeded: row.tagsSeeded == 1,
       playerOrientation: playerOrientation,
+      autoScrollSpeed: row.autoScrollSpeed,
     );
   }
 }

--- a/lib/shared/models/user_preferences.dart
+++ b/lib/shared/models/user_preferences.dart
@@ -147,6 +147,8 @@ class UserPreferences {
   ///   `false`.
   /// - [playerOrientation]: Screen orientation lock for the notation player.
   ///   Defaults to [PlayerOrientation.auto].
+  /// - [autoScrollSpeed]: Auto-scroll speed multiplier in the range
+  ///   [0.1, 3.0]. Defaults to `1.0`.
   const UserPreferences({
     required this.userName,
     required this.themeMode,
@@ -156,6 +158,7 @@ class UserPreferences {
     required this.defaultView,
     this.tagsSeeded = false,
     this.playerOrientation = PlayerOrientation.auto,
+    this.autoScrollSpeed = 1.0,
   });
 
   /// Display name shown in the application UI.
@@ -187,6 +190,11 @@ class UserPreferences {
   /// Defaults to [PlayerOrientation.auto] (sensor-driven, no lock).
   final PlayerOrientation playerOrientation;
 
+  /// Auto-scroll speed multiplier for the notation player.
+  ///
+  /// Valid range: [0.1, 3.0]. Defaults to `1.0` (1× speed).
+  final double autoScrollSpeed;
+
   /// Returns a copy of this [UserPreferences] with the specified fields
   /// replaced.
   ///
@@ -200,6 +208,7 @@ class UserPreferences {
     ViewMode? defaultView,
     bool? tagsSeeded,
     PlayerOrientation? playerOrientation,
+    double? autoScrollSpeed,
   }) =>
       UserPreferences(
         userName: userName ?? this.userName,
@@ -210,6 +219,7 @@ class UserPreferences {
         defaultView: defaultView ?? this.defaultView,
         tagsSeeded: tagsSeeded ?? this.tagsSeeded,
         playerOrientation: playerOrientation ?? this.playerOrientation,
+        autoScrollSpeed: autoScrollSpeed ?? this.autoScrollSpeed,
       );
 
   /// Deserializes [UserPreferences] from a JSON map.
@@ -231,7 +241,8 @@ class UserPreferences {
           defaultSort == other.defaultSort &&
           defaultView == other.defaultView &&
           tagsSeeded == other.tagsSeeded &&
-          playerOrientation == other.playerOrientation;
+          playerOrientation == other.playerOrientation &&
+          autoScrollSpeed == other.autoScrollSpeed;
 
   @override
   int get hashCode => Object.hash(
@@ -243,6 +254,7 @@ class UserPreferences {
         defaultView,
         tagsSeeded,
         playerOrientation,
+        autoScrollSpeed,
       );
 
   @override

--- a/lib/shared/models/user_preferences.g.dart
+++ b/lib/shared/models/user_preferences.g.dart
@@ -19,6 +19,7 @@ UserPreferences _$UserPreferencesFromJson(Map<String, dynamic> json) =>
       playerOrientation: $enumDecodeNullable(
               _$PlayerOrientationEnumMap, json['player_orientation']) ??
           PlayerOrientation.auto,
+      autoScrollSpeed: (json['auto_scroll_speed'] as num?)?.toDouble() ?? 1.0,
     );
 
 Map<String, dynamic> _$UserPreferencesToJson(UserPreferences instance) =>
@@ -32,6 +33,7 @@ Map<String, dynamic> _$UserPreferencesToJson(UserPreferences instance) =>
       'tags_seeded': instance.tagsSeeded,
       'player_orientation':
           _$PlayerOrientationEnumMap[instance.playerOrientation]!,
+      'auto_scroll_speed': instance.autoScrollSpeed,
     };
 
 const _$AppThemeModeEnumMap = {

--- a/lib/shared/repositories/preferences_repository.dart
+++ b/lib/shared/repositories/preferences_repository.dart
@@ -63,6 +63,15 @@ abstract interface class PreferencesRepository
   /// - [orientation]: The new [PlayerOrientation] to persist.
   Future<void> updatePlayerOrientation(PlayerOrientation orientation);
 
+  /// Updates the `auto_scroll_speed` field to [speed].
+  ///
+  /// All other preference fields are left unchanged. [speed] must be in the
+  /// range [0.1, 3.0]; the implementation clamps to this range.
+  ///
+  /// Parameters:
+  /// - [speed]: The new auto-scroll speed multiplier to persist.
+  Future<void> updateAutoScrollSpeed(double speed);
+
   /// Convenience method to flip the `tagsSeeded` flag.
   ///
   /// Parameters:

--- a/test/unit/core/database/migration_test.dart
+++ b/test/unit/core/database/migration_test.dart
@@ -1,4 +1,4 @@
-// Migration tests for AppDatabase — schema v4.
+// Migration tests for AppDatabase — schema v5.
 //
 // Verifies that [MigrationStrategy.onCreate] produces the exact schema
 // described in docs/02-technical/data-model.md, including:
@@ -6,7 +6,7 @@
 //   - All 9 indexes (partial and non-partial)
 //   - The FTS5 virtual table (notations_fts) and its 3 sync triggers
 //   - Seed data: 5 default tags and the singleton user_preferences row
-//   - schemaVersion == 4
+//   - schemaVersion == 5
 //
 // [validateDatabaseSchema] (from drift_dev/api/migrations_native.dart) is
 // used to compare the live schema against Drift's reference schema, giving
@@ -110,18 +110,18 @@ void main() {
   setUpAll(() => driftRuntimeOptions.dontWarnAboutMultipleDatabases = true);
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — schema version', () {
+  group('Migration v5 — schema version', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
 
-    test('schemaVersion is 4', () {
-      expect(db.schemaVersion, 4);
+    test('schemaVersion is 5', () {
+      expect(db.schemaVersion, 5);
     });
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — Drift schema validation', () {
+  group('Migration v5 — Drift schema validation', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -146,7 +146,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — table presence', () {
+  group('Migration v5 — table presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -160,7 +160,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — index presence', () {
+  group('Migration v5 — index presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -174,7 +174,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — FTS5 virtual table and triggers', () {
+  group('Migration v5 — FTS5 virtual table and triggers', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -219,7 +219,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — seed data', () {
+  group('Migration v5 — seed data', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -261,11 +261,12 @@ void main() {
       expect(prefs.userName, 'Musician');
       expect(prefs.tagsSeeded, 0);
       expect(prefs.playerOrientation, 'auto');
+      expect(prefs.autoScrollSpeed, closeTo(1.0, 0.001));
     });
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v4 — forTesting mode has no seed data', () {
+  group('Migration v5 — forTesting mode has no seed data', () {
     late AppDatabase db;
     setUp(() {
       db = AppDatabase.forTesting();

--- a/test/unit/features/player/viewmodels/notation_player_view_model_auto_scroll_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_auto_scroll_test.dart
@@ -1,0 +1,450 @@
+// Unit tests for auto-scroll behaviour in NotationPlayerViewModel (#94).
+//
+// Covers:
+//   autoScrollEnabled   → initial false; toggleAutoScroll flips it
+//   autoScrollSpeed     → initial default; setScrollSpeed clamps to range
+//   scroll step calc    → calculateScrollStep returns correct px/tick
+//   persistence         → setScrollSpeed calls updateAutoScrollSpeed
+//   loadPersistedSpeed  → speed loaded from repository on init
+//   auto-scroll stops   → stopAutoScroll resets flag
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swaralipi/features/player/viewmodels/notation_player_view_model.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeNotationRepository implements NotationRepository {
+  NotationDetail? _detail;
+
+  void setDetail(NotationDetail? d) => _detail = d;
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async => _detail;
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> softDelete(String id) async => throw UnimplementedError();
+
+  @override
+  Stream<List<Notation>> watchAllActive() => const Stream.empty();
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async =>
+      throw UnimplementedError();
+}
+
+class FakePreferencesRepository implements PreferencesRepository {
+  double? lastSavedSpeed;
+  bool updateAutoScrollSpeedCalled = false;
+
+  UserPreferences _prefs = const UserPreferences(
+    userName: 'Test',
+    themeMode: AppThemeMode.system,
+    colorSchemeMode: ColorSchemeMode.catppuccin,
+    defaultSort: SortOrder.createdAtDesc,
+    defaultView: ViewMode.list,
+    autoScrollSpeed: kDefaultAutoScrollSpeed,
+  );
+
+  void setPrefs(UserPreferences prefs) => _prefs = prefs;
+
+  @override
+  Future<UserPreferences> getPreferences() async => _prefs;
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {
+    _prefs = preferences;
+  }
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {
+    updateAutoScrollSpeedCalled = true;
+    lastSavedSpeed = speed;
+    _prefs = _prefs.copyWith(autoScrollSpeed: speed);
+  }
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeNotationRepository notationRepo;
+  late FakePreferencesRepository prefsRepo;
+
+  setUp(() {
+    notationRepo = FakeNotationRepository();
+    prefsRepo = FakePreferencesRepository();
+  });
+
+  // -------------------------------------------------------------------------
+  // Constants
+  // -------------------------------------------------------------------------
+
+  group('auto-scroll constants', () {
+    test('kDefaultAutoScrollSpeed is within valid range', () {
+      expect(
+          kDefaultAutoScrollSpeed, greaterThanOrEqualTo(kMinAutoScrollSpeed));
+      expect(kDefaultAutoScrollSpeed, lessThanOrEqualTo(kMaxAutoScrollSpeed));
+    });
+
+    test('kMinAutoScrollSpeed is 0.1', () {
+      expect(kMinAutoScrollSpeed, closeTo(0.1, 0.001));
+    });
+
+    test('kMaxAutoScrollSpeed is 3.0', () {
+      expect(kMaxAutoScrollSpeed, closeTo(3.0, 0.001));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial auto-scroll state
+  // -------------------------------------------------------------------------
+
+  group('initial auto-scroll state', () {
+    test('autoScrollEnabled is false initially', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      expect(vm.autoScrollEnabled, isFalse);
+    });
+
+    test('autoScrollSpeed defaults to kDefaultAutoScrollSpeed', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      expect(vm.autoScrollSpeed, equals(kDefaultAutoScrollSpeed));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toggleAutoScroll
+  // -------------------------------------------------------------------------
+
+  group('toggleAutoScroll', () {
+    test('enables auto-scroll when disabled', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      vm.toggleAutoScroll();
+
+      expect(vm.autoScrollEnabled, isTrue);
+    });
+
+    test('disables auto-scroll when enabled', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      vm.toggleAutoScroll();
+
+      vm.toggleAutoScroll();
+
+      expect(vm.autoScrollEnabled, isFalse);
+    });
+
+    test('notifies listeners on toggle', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      vm.toggleAutoScroll();
+
+      expect(notified, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setScrollSpeed
+  // -------------------------------------------------------------------------
+
+  group('setScrollSpeed', () {
+    test('updates autoScrollSpeed to valid value', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setScrollSpeed(1.5);
+
+      expect(vm.autoScrollSpeed, closeTo(1.5, 0.001));
+    });
+
+    test('clamps speed below kMinAutoScrollSpeed to minimum', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setScrollSpeed(0.0);
+
+      expect(vm.autoScrollSpeed, closeTo(kMinAutoScrollSpeed, 0.001));
+    });
+
+    test('clamps speed above kMaxAutoScrollSpeed to maximum', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setScrollSpeed(10.0);
+
+      expect(vm.autoScrollSpeed, closeTo(kMaxAutoScrollSpeed, 0.001));
+    });
+
+    test('notifies listeners when speed changes', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      await vm.setScrollSpeed(2.0);
+
+      expect(notified, isTrue);
+    });
+
+    test('does not notify when same speed is set again', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      await vm.setScrollSpeed(1.5);
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      await vm.setScrollSpeed(1.5);
+
+      expect(notified, isFalse);
+    });
+
+    test('persists speed to PreferencesRepository', () async {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.setScrollSpeed(2.0);
+
+      expect(prefsRepo.updateAutoScrollSpeedCalled, isTrue);
+      expect(prefsRepo.lastSavedSpeed, closeTo(2.0, 0.001));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loadPersistedSpeed
+  // -------------------------------------------------------------------------
+
+  group('loadPersistedSpeed', () {
+    test('loads persisted speed from repository', () async {
+      prefsRepo.setPrefs(const UserPreferences(
+        userName: 'Test',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+        autoScrollSpeed: 2.5,
+      ));
+
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      await vm.loadPersistedSpeed();
+
+      expect(vm.autoScrollSpeed, closeTo(2.5, 0.001));
+    });
+
+    test('notifies listeners after loading persisted speed', () async {
+      prefsRepo.setPrefs(const UserPreferences(
+        userName: 'Test',
+        themeMode: AppThemeMode.system,
+        colorSchemeMode: ColorSchemeMode.catppuccin,
+        defaultSort: SortOrder.createdAtDesc,
+        defaultView: ViewMode.list,
+        autoScrollSpeed: 1.8,
+      ));
+
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      await vm.loadPersistedSpeed();
+
+      expect(notified, isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // stopAutoScroll
+  // -------------------------------------------------------------------------
+
+  group('stopAutoScroll', () {
+    test('disables auto-scroll', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      vm.toggleAutoScroll(); // enable first
+
+      vm.stopAutoScroll();
+
+      expect(vm.autoScrollEnabled, isFalse);
+    });
+
+    test('notifies listeners when stopping', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+      vm.toggleAutoScroll(); // enable first
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      vm.stopAutoScroll();
+
+      expect(notified, isTrue);
+    });
+
+    test('does nothing (no notification) when already disabled', () {
+      final vm = NotationPlayerViewModel(
+        notationRepo,
+        preferencesRepository: prefsRepo,
+        notationId: 'n1',
+      );
+
+      var notified = false;
+      vm.addListener(() => notified = true);
+      vm.stopAutoScroll();
+
+      expect(notified, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // calculateScrollStep
+  // -------------------------------------------------------------------------
+
+  group('calculateScrollStep', () {
+    test('returns positive step for valid viewport and speed', () {
+      final step = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 50,
+      );
+      expect(step, greaterThan(0));
+    });
+
+    test('step scales linearly with speed multiplier', () {
+      final step1 = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 50,
+      );
+      final step2 = NotationPlayerViewModel.calculateScrollStep(
+        speed: 2.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 50,
+      );
+      expect(step2, closeTo(step1 * 2.0, 0.001));
+    });
+
+    test('step scales with viewport height', () {
+      final step400 = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 400.0,
+        tickIntervalMs: 50,
+      );
+      final step800 = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 50,
+      );
+      expect(step800, greaterThan(step400));
+    });
+
+    test('step is smaller for shorter tick interval', () {
+      final step50ms = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 50,
+      );
+      final step100ms = NotationPlayerViewModel.calculateScrollStep(
+        speed: 1.0,
+        viewportHeight: 800.0,
+        tickIntervalMs: 100,
+      );
+      // 100ms tick fires half as often as 50ms, so each tick must move more
+      expect(step100ms, greaterThan(step50ms));
+    });
+  });
+}

--- a/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
@@ -96,6 +96,9 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateSeedColor(String? colorHex) async {}
 
   @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {}
 }
 

--- a/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
@@ -102,6 +102,9 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateSeedColor(String? colorHex) async {}
 
   @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {}
 }
 

--- a/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
+++ b/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
@@ -78,6 +78,11 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
     _prefs = _prefs.copyWith(playerOrientation: orientation);
   }
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {
+    _prefs = _prefs.copyWith(autoScrollSpeed: speed);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/widget/features/player/notation_player_screen_orientation_test.dart
+++ b/test/widget/features/player/notation_player_screen_orientation_test.dart
@@ -97,6 +97,9 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateSeedColor(String? colorHex) async {}
 
   @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {}
 }
 

--- a/test/widget/features/player/notation_player_screen_test.dart
+++ b/test/widget/features/player/notation_player_screen_test.dart
@@ -100,6 +100,9 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateSeedColor(String? colorHex) async {}
 
   @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
   Future<void> updateTagsSeeded({required bool value}) async {}
 }
 

--- a/test/widget/features/settings/appearance_screen_test.dart
+++ b/test/widget/features/settings/appearance_screen_test.dart
@@ -84,6 +84,11 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
     _prefs = _prefs.copyWith(playerOrientation: orientation);
   }
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {
+    _prefs = _prefs.copyWith(autoScrollSpeed: speed);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +136,9 @@ class _BlockingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
 }
 
 // ---------------------------------------------------------------------------
@@ -327,4 +335,7 @@ class _FailingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
 }


### PR DESCRIPTION
## Linked Issue

Closes #94

## Summary

- Added `auto_scroll_speed` REAL column to `user_preferences_table` (schema v5 migration, CHECK constraint 0.1–3.0, default 1.0)
- `NotationPlayerViewModel` gains auto-scroll state (`autoScrollEnabled`, `autoScrollSpeed`), toggle/stop methods, `setScrollSpeed` (persists), `updateScrollSpeedLocal` (in-memory, for drag frames), `loadPersistedSpeed`, and static `calculateScrollStep`
- `NotationPlayerScreen` drives smooth scroll via `Timer.periodic` at 50 ms tick, pauses on swipe gesture via `ScrollNotification`, stops at end of content; bottom chrome gains auto-scroll toggle button and speed slider (0.1×–3.0×) visible when enabled
- Speed persisted on slider drag end, restored on every player open via `loadPersistedSpeed`

## Type of Change

- feat

## Commit Convention

`feat(player): implement auto-scroll at configurable speed with persisted preference (#94)`

## Test Plan

- `test/unit/features/player/viewmodels/notation_player_view_model_auto_scroll_test.dart` — 23 new unit tests covering: constants, initial state, toggleAutoScroll, setScrollSpeed (clamping, persistence, dedup), loadPersistedSpeed, stopAutoScroll, calculateScrollStep (linearity, viewport scaling, tick interval)
- All existing player ViewModel and screen tests updated for new interface method (`updateAutoScrollSpeed`) — 1064 tests pass total
- `test/unit/core/database/migration_test.dart` updated to v5: schema version assertion + `autoScrollSpeed` default value check

## Checklist

- [x] All tests pass (`flutter test test/` — 1064 passed, 0 failed)
- [x] `dart format --line-length 80` — 0 changes
- [x] `flutter analyze` — 0 new warnings (4 pre-existing info items in untouched files)
- [x] Code review: no CRITICAL or HIGH issues
- [x] PR opened, linked to issue