### PR TITLE
feat(settings): implement SettingsScreen shell with navigation tiles (#99)

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -1,0 +1,172 @@
+// SettingsScreen — navigational shell for all settings sub-sections.
+//
+// Route: /settings
+//
+// The screen renders a [ListView] of [ListTile]s, each navigating to a
+// settings sub-section via [GoRouter]:
+//   • Tags            → /settings/tags
+//   • Instruments     → /settings/instruments
+//   • Trash           → /settings/trash
+//   • Appearance      → /settings/appearance
+//   • Custom Fields   → /settings/custom-fields
+//   • About           → inline tile displaying app name + version
+//
+// The screen holds no state of its own. [PackageInfo] is loaded once via
+// [FutureBuilder] to populate the About tile. All other tiles are static.
+
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Padding at the top and bottom of the settings list.
+const EdgeInsets _kListPadding = EdgeInsets.symmetric(vertical: 8);
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Navigational shell screen for all settings sub-sections.
+///
+/// Renders a [ListView] of navigation tiles. Tapping a tile calls
+/// [GoRouter.go] to the corresponding sub-route. The About tile shows the
+/// app name and version from [PackageInfo].
+///
+/// This screen is stateless with respect to user-editable data. It loads
+/// [PackageInfo] once on first build via a [FutureBuilder].
+class SettingsScreen extends StatelessWidget {
+  /// Creates a [SettingsScreen].
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: FutureBuilder<PackageInfo>(
+        future: PackageInfo.fromPlatform(),
+        builder: (context, snapshot) {
+          final info = snapshot.data;
+          return ListView(
+            padding: _kListPadding,
+            children: [
+              _SettingsTile(
+                icon: Icons.label_outline,
+                title: 'Tags',
+                onTap: () => context.go('/settings/tags'),
+              ),
+              _SettingsTile(
+                icon: Icons.music_note_outlined,
+                title: 'Instruments',
+                onTap: () => context.go('/settings/instruments'),
+              ),
+              _SettingsTile(
+                icon: Icons.delete_outline,
+                title: 'Trash',
+                onTap: () => context.go('/settings/trash'),
+              ),
+              _SettingsTile(
+                icon: Icons.palette_outlined,
+                title: 'Appearance',
+                onTap: () => context.go('/settings/appearance'),
+              ),
+              _SettingsTile(
+                icon: Icons.tune_outlined,
+                title: 'Custom Fields',
+                onTap: () => context.go('/settings/custom-fields'),
+              ),
+              const Divider(),
+              _AboutTile(info: info),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private widgets
+// ---------------------------------------------------------------------------
+
+/// A single navigational [ListTile] in the settings list.
+///
+/// Displays a leading [icon], a [title] label, and a trailing chevron.
+/// Calls [onTap] when tapped.
+class _SettingsTile extends StatelessWidget {
+  const _SettingsTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+  });
+
+  /// Icon displayed as the leading element.
+  final IconData icon;
+
+  /// Label text for the tile.
+  final String title;
+
+  /// Callback invoked when the tile is tapped.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Semantics(
+      button: true,
+      label: title,
+      child: ListTile(
+        leading: Icon(icon, color: colorScheme.onSurfaceVariant),
+        title: Text(title),
+        trailing: Icon(
+          Icons.chevron_right,
+          color: colorScheme.onSurfaceVariant,
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+/// The About tile, showing app name and version.
+///
+/// Displays a loading indicator while [PackageInfo] is being fetched.
+/// Falls back to an empty subtitle when [info] is null (unexpected).
+class _AboutTile extends StatelessWidget {
+  const _AboutTile({required this.info});
+
+  /// The resolved [PackageInfo], or null while loading.
+  final PackageInfo? info;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (info == null) {
+      log('_AboutTile: PackageInfo not yet available', name: 'SettingsScreen');
+      return ListTile(
+        leading: Icon(Icons.info_outline, color: colorScheme.onSurfaceVariant),
+        title: const Text('About'),
+        subtitle: const LinearProgressIndicator(),
+      );
+    }
+
+    final versionString = '${info!.appName} ${info!.version}';
+    return ListTile(
+      leading: Icon(Icons.info_outline, color: colorScheme.onSurfaceVariant),
+      title: const Text('About'),
+      subtitle: Text(
+        versionString,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -616,6 +624,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1021,6 +1045,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   material_symbols_icons: ^4.2928.1
   uuid: ^4.5.3
   permission_handler: ^12.0.1
+  package_info_plus: ^10.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget/features/settings/settings_screen_test.dart
+++ b/test/widget/features/settings/settings_screen_test.dart
@@ -1,0 +1,221 @@
+// Widget tests for SettingsScreen.
+//
+// Covers rendering and navigation tile routing for SettingsScreen:
+//   - renders all six navigation tiles (Tags, Instruments, Trash,
+//     Appearance, Custom Fields, About)
+//   - About tile shows app name and version string
+//   - tapping Tags tile triggers go_router navigation to /settings/tags
+//   - tapping Instruments tile triggers navigation to /settings/instruments
+//   - tapping Trash tile triggers navigation to /settings/trash
+//   - tapping Appearance tile triggers navigation to /settings/appearance
+//   - tapping Custom Fields tile triggers navigation to /settings/custom-fields
+//
+// Naming convention:
+//   <widget/scenario> → <expected outcome>
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'package:swaralipi/features/settings/screens/settings_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a testable [SettingsScreen] wrapped in a [GoRouter] that records
+/// the last navigation destination.
+Widget _buildApp({
+  required List<String> navigatedRoutes,
+  String appName = 'Swaralipi',
+  String version = '1.2.3',
+  String buildNumber = '42',
+}) {
+  PackageInfo.setMockInitialValues(
+    appName: appName,
+    packageName: 'com.example.swaralipi',
+    version: version,
+    buildNumber: buildNumber,
+    buildSignature: '',
+  );
+
+  final router = GoRouter(
+    initialLocation: '/settings',
+    routes: [
+      GoRoute(
+        path: '/settings',
+        builder: (_, __) => const SettingsScreen(),
+        routes: [
+          GoRoute(
+            path: 'tags',
+            builder: (_, __) {
+              navigatedRoutes.add('/settings/tags');
+              return const _StubScreen(label: 'tags');
+            },
+          ),
+          GoRoute(
+            path: 'instruments',
+            builder: (_, __) {
+              navigatedRoutes.add('/settings/instruments');
+              return const _StubScreen(label: 'instruments');
+            },
+          ),
+          GoRoute(
+            path: 'trash',
+            builder: (_, __) {
+              navigatedRoutes.add('/settings/trash');
+              return const _StubScreen(label: 'trash');
+            },
+          ),
+          GoRoute(
+            path: 'appearance',
+            builder: (_, __) {
+              navigatedRoutes.add('/settings/appearance');
+              return const _StubScreen(label: 'appearance');
+            },
+          ),
+          GoRoute(
+            path: 'custom-fields',
+            builder: (_, __) {
+              navigatedRoutes.add('/settings/custom-fields');
+              return const _StubScreen(label: 'custom-fields');
+            },
+          ),
+        ],
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    routerConfig: router,
+    theme: ThemeData(useMaterial3: true),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stub destinations
+// ---------------------------------------------------------------------------
+
+class _StubScreen extends StatelessWidget {
+  const _StubScreen({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Text(label);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('SettingsScreen —', () {
+    group('renders all navigation tiles', () {
+      testWidgets(
+        'shows Tags, Instruments, Trash, Appearance, Custom Fields tiles',
+        (tester) async {
+          await tester.pumpWidget(_buildApp(navigatedRoutes: []));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Tags'), findsOneWidget);
+          expect(find.text('Instruments'), findsOneWidget);
+          expect(find.text('Trash'), findsOneWidget);
+          expect(find.text('Appearance'), findsOneWidget);
+          expect(find.text('Custom Fields'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'About tile shows app name and version',
+        (tester) async {
+          await tester.pumpWidget(
+            _buildApp(
+              navigatedRoutes: [],
+              appName: 'Swaralipi',
+              version: '2.0.0',
+              buildNumber: '10',
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('About'), findsOneWidget);
+          expect(find.textContaining('2.0.0'), findsOneWidget);
+        },
+      );
+    });
+
+    group('navigation tile routing', () {
+      testWidgets(
+        'tapping Tags tile navigates to /settings/tags',
+        (tester) async {
+          final routes = <String>[];
+          await tester.pumpWidget(_buildApp(navigatedRoutes: routes));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Tags'));
+          await tester.pumpAndSettle();
+
+          expect(routes, contains('/settings/tags'));
+        },
+      );
+
+      testWidgets(
+        'tapping Instruments tile navigates to /settings/instruments',
+        (tester) async {
+          final routes = <String>[];
+          await tester.pumpWidget(_buildApp(navigatedRoutes: routes));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Instruments'));
+          await tester.pumpAndSettle();
+
+          expect(routes, contains('/settings/instruments'));
+        },
+      );
+
+      testWidgets(
+        'tapping Trash tile navigates to /settings/trash',
+        (tester) async {
+          final routes = <String>[];
+          await tester.pumpWidget(_buildApp(navigatedRoutes: routes));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Trash'));
+          await tester.pumpAndSettle();
+
+          expect(routes, contains('/settings/trash'));
+        },
+      );
+
+      testWidgets(
+        'tapping Appearance tile navigates to /settings/appearance',
+        (tester) async {
+          final routes = <String>[];
+          await tester.pumpWidget(_buildApp(navigatedRoutes: routes));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Appearance'));
+          await tester.pumpAndSettle();
+
+          expect(routes, contains('/settings/appearance'));
+        },
+      );
+
+      testWidgets(
+        'tapping Custom Fields tile navigates to /settings/custom-fields',
+        (tester) async {
+          final routes = <String>[];
+          await tester.pumpWidget(_buildApp(navigatedRoutes: routes));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Custom Fields'));
+          await tester.pumpAndSettle();
+
+          expect(routes, contains('/settings/custom-fields'));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked Issue
Closes #99

## Summary
- Adds `SettingsScreen` at `/settings` as a `ListView` of `ListTile`s navigating to all sub-sections
- Adds `package_info_plus` dependency to display app name and version in the About tile
- `SettingsScreen` is stateless — purely navigational, no business logic
- All navigation uses `go_router` (`context.go`) to sub-routes under `/settings`

## Type of Change
- [x] feat — new capability

## Commit Convention
`feat(settings): implement SettingsScreen shell with navigation tiles (#99)`

## Test Plan
- [x] Widget tests written: `test/widget/features/settings/settings_screen_test.dart`
- [x] 7 widget tests covering: all 6 tile renders, About tile version display, and all 5 navigation tile routes
- [x] `flutter test` passes — 987 unit tests + 7 new widget tests, all green
- [x] `flutter analyze` — zero warnings on changed files
- [x] `dart format` applied — no changes needed

## Screenshots / Recordings
No screenshot required for this shell screen (static list, no new visual components).

## Checklist
- [x] No `print` statements (uses `dart:developer` `log`)
- [x] No relative imports
- [x] No `late` without guaranteed init
- [x] No bare `catch (e)`
- [x] Generated files committed (`.g.dart`) — no new generated files
- [x] No hardcoded secrets