### PR TITLE
feat(settings): wire all Settings sub-routes into GoRouter (#100)

### DIFF
--- a/integration_test/settings/settings_navigation_test.dart
+++ b/integration_test/settings/settings_navigation_test.dart
@@ -1,0 +1,355 @@
+// Integration tests for Settings sub-route navigation.
+//
+// Verifies that tapping each settings tile from SettingsScreen navigates to
+// the correct sub-screen and that back navigation returns to SettingsScreen
+// without resetting ViewModel state.
+//
+// The full SwaralipiApp is pumped with all dependencies wired via fake
+// repositories, exercising the real GoRouter configuration.
+//
+// Covered routes:
+//   /settings/tags         — TagsScreen
+//   /settings/instruments  — InstrumentClassesScreen
+//   /settings/trash        — TrashScreen
+//   /settings/appearance   — AppearanceScreen
+//   /settings/custom-fields — CustomFieldsScreen
+//
+// Naming convention:
+//   <starting state> → <action> → <expected result>
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'package:swaralipi/app.dart';
+import 'package:swaralipi/shared/models/custom_field_definition.dart';
+import 'package:swaralipi/shared/models/instrument_class.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/tag.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/models/instrument_instance.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fake repositories
+// ---------------------------------------------------------------------------
+
+class _FakeTagRepository implements TagRepository {
+  @override
+  Stream<List<Tag>> watchAllTags() => Stream.value([]);
+  @override
+  Future<Tag> createTag(String name, String colorHex) async => _kStubTag;
+
+  @override
+  Future<Tag> updateTag(String id, {String? name, String? colorHex}) async =>
+      _kStubTag;
+  @override
+  Future<void> deleteTag(String id) async {}
+  @override
+  Future<void> seedDefaultTagsIfNeeded() async {}
+}
+
+const Tag _kStubTag = Tag(
+  id: 'tag-1',
+  name: 'stub',
+  colorHex: '#ffffff',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+);
+
+class _FakeTrashRepository implements TrashRepository {
+  @override
+  Stream<List<Notation>> watchTrashedNotations() => Stream.value([]);
+  @override
+  Future<void> restoreNotation(String id) async {}
+  @override
+  Future<void> purgeNotation(String id) async {}
+  @override
+  Future<void> purgeAll() async {}
+  @override
+  Future<int> autoPurgeExpired() async => 0;
+}
+
+class _FakeInstrumentRepository implements InstrumentRepository {
+  @override
+  Stream<List<InstrumentClass>> watchActiveClasses() => Stream.value([]);
+  @override
+  Future<InstrumentClass> createClass(String name) async => InstrumentClass(
+        id: 'ic-1',
+        name: name,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      );
+
+  @override
+  Future<InstrumentClass> updateClass(String id, String name) async =>
+      InstrumentClass(
+        id: id,
+        name: name,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      );
+  @override
+  Future<void> archiveClass(String id) async {}
+  @override
+  Stream<List<InstrumentInstance>> watchActiveInstancesForClass(
+    String classId,
+  ) =>
+      Stream.value([]);
+  @override
+  Future<InstrumentInstance> createInstance(
+    String classId, {
+    required String colorHex,
+    String? brand,
+    String? model,
+    int? priceInr,
+    String? photoPath,
+    String notes = '',
+  }) =>
+      throw UnimplementedError();
+  @override
+  Future<InstrumentInstance> updateInstance(
+    String id, {
+    String? brand,
+    String? model,
+    String? colorHex,
+    int? priceInr,
+    String? photoPath,
+    String? notes,
+  }) =>
+      throw UnimplementedError();
+  @override
+  Future<void> archiveInstance(String id) async {}
+}
+
+class _FakeCustomFieldRepository implements CustomFieldRepository {
+  @override
+  Stream<List<CustomFieldDefinition>> watchAllDefinitions() => Stream.value([]);
+  @override
+  Future<CustomFieldDefinition> createDefinition(
+    String keyName,
+    String fieldType,
+  ) =>
+      throw UnimplementedError();
+  @override
+  Future<CustomFieldDefinition> updateDefinition(
+    String id, {
+    String? keyName,
+    String? fieldType,
+  }) =>
+      throw UnimplementedError();
+  @override
+  Future<void> deleteDefinition(String id) async {}
+}
+
+class _FakePreferencesRepository implements PreferencesRepository {
+  UserPreferences _prefs = const UserPreferences(
+    userName: '',
+    themeMode: AppThemeMode.system,
+    colorSchemeMode: ColorSchemeMode.catppuccin,
+    defaultSort: SortOrder.createdAtDesc,
+    defaultView: ViewMode.list,
+  );
+
+  @override
+  Future<UserPreferences> getPreferences() async => _prefs;
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {
+    _prefs = preferences;
+  }
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {
+    _prefs = _prefs.copyWith(themeMode: mode);
+  }
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {
+    _prefs = _prefs.copyWith(colorSchemeMode: mode);
+  }
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {
+    _prefs = _prefs.copyWith(seedColor: colorHex);
+  }
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {
+    _prefs = _prefs.copyWith(playerOrientation: orientation);
+  }
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {
+    _prefs = _prefs.copyWith(autoScrollSpeed: speed);
+  }
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {
+    _prefs = _prefs.copyWith(tagsSeeded: value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Builds [SwaralipiApp] pre-seeded with fake repositories and navigates
+/// directly to /settings by providing a test router seeded at /settings.
+Widget _buildAppAtSettings({
+  _FakeTagRepository? tagRepo,
+  _FakeTrashRepository? trashRepo,
+  _FakeInstrumentRepository? instrumentRepo,
+  _FakeCustomFieldRepository? customFieldRepo,
+  _FakePreferencesRepository? prefsRepo,
+}) {
+  PackageInfo.setMockInitialValues(
+    appName: 'Swaralipi',
+    packageName: 'com.example.swaralipi',
+    version: '0.1.0',
+    buildNumber: '1',
+    buildSignature: '',
+  );
+
+  return SwaralipiApp.forTesting(
+    initialLocation: '/settings',
+    tagRepository: tagRepo ?? _FakeTagRepository(),
+    trashRepository: trashRepo ?? _FakeTrashRepository(),
+    instrumentRepository: instrumentRepo ?? _FakeInstrumentRepository(),
+    customFieldRepository: customFieldRepo ?? _FakeCustomFieldRepository(),
+    preferencesRepository: prefsRepo ?? _FakePreferencesRepository(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Settings sub-route navigation —', () {
+    testWidgets(
+      'tapping Tags tile renders TagsScreen at /settings/tags',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Settings'), findsOneWidget);
+        expect(find.text('Tags'), findsOneWidget);
+
+        await tester.tap(find.text('Tags'));
+        await tester.pumpAndSettle();
+
+        // TagsScreen has an AppBar titled 'Tags'
+        expect(find.widgetWithText(AppBar, 'Tags'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping Instruments tile renders InstrumentClassesScreen at '
+      '/settings/instruments',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Instruments'));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(AppBar, 'Instruments'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping Trash tile renders TrashScreen at /settings/trash',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Trash'));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(AppBar, 'Trash'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping Appearance tile renders AppearanceScreen at '
+      '/settings/appearance',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Appearance'));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(AppBar, 'Appearance'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping Custom Fields tile renders CustomFieldsScreen at '
+      '/settings/custom-fields',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Custom Fields'));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(AppBar, 'Custom Fields'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'back navigation from Tags sub-screen returns to SettingsScreen',
+      (tester) async {
+        await tester.pumpWidget(_buildAppAtSettings());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Tags'));
+        await tester.pumpAndSettle();
+
+        // Navigate back using the back button
+        final NavigatorState navigator = tester.state(find.byType(Navigator));
+        navigator.pop();
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(AppBar, 'Settings'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'deep-link navigation directly to /settings/tags does not crash',
+      (tester) async {
+        PackageInfo.setMockInitialValues(
+          appName: 'Swaralipi',
+          packageName: 'com.example.swaralipi',
+          version: '0.1.0',
+          buildNumber: '1',
+          buildSignature: '',
+        );
+
+        await tester.pumpWidget(
+          SwaralipiApp.forTesting(
+            initialLocation: '/settings/tags',
+            tagRepository: _FakeTagRepository(),
+            trashRepository: _FakeTrashRepository(),
+            instrumentRepository: _FakeInstrumentRepository(),
+            customFieldRepository: _FakeCustomFieldRepository(),
+            preferencesRepository: _FakePreferencesRepository(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.widgetWithText(AppBar, 'Tags'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,277 @@
+// app.dart — root widget and GoRouter configuration for Swaralipi.
+//
+// [SwaralipiApp] is the single entry point used by both [main.dart] (production)
+// and integration tests ([SwaralipiApp.forTesting]).  It wires:
+//   • The full GoRouter route tree (all settings sub-routes)
+//   • Dependency injection: repositories created once, passed down as
+//     ChangeNotifierProvider at each route builder
+//
+// Route tree:
+//   /                        → LibraryScreen
+//   /settings                → SettingsScreen
+//   /settings/tags           → TagsScreen
+//   /settings/instruments    → InstrumentClassesScreen
+//   /settings/trash          → TrashScreen
+//   /settings/appearance     → AppearanceScreen
+//   /settings/custom-fields  → CustomFieldsScreen
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/core/database/app_database.dart';
+import 'package:swaralipi/core/storage/file_storage_service.dart';
+import 'package:swaralipi/features/custom_fields/data/custom_field_repository_impl.dart';
+import 'package:swaralipi/features/custom_fields/screens/custom_fields_screen.dart';
+import 'package:swaralipi/features/custom_fields/viewmodels/custom_fields_view_model.dart';
+import 'package:swaralipi/features/instruments/data/instrument_repository_impl.dart';
+import 'package:swaralipi/features/instruments/screens/instrument_classes_screen.dart';
+import 'package:swaralipi/features/instruments/viewmodels/instrument_classes_view_model.dart';
+import 'package:swaralipi/features/library/screens/library_screen.dart';
+import 'package:swaralipi/features/library/viewmodels/library_view_model.dart';
+import 'package:swaralipi/features/settings/data/user_preferences_repository_impl.dart';
+import 'package:swaralipi/features/settings/screens/appearance_screen.dart';
+import 'package:swaralipi/features/settings/screens/settings_screen.dart';
+import 'package:swaralipi/features/settings/viewmodels/appearance_view_model.dart';
+import 'package:swaralipi/features/tags/data/tag_repository_impl.dart';
+import 'package:swaralipi/features/tags/screens/tags_screen.dart';
+import 'package:swaralipi/features/tags/viewmodels/tags_view_model.dart';
+import 'package:swaralipi/features/trash/data/trash_repository_impl.dart';
+import 'package:swaralipi/features/trash/screens/trash_screen.dart';
+import 'package:swaralipi/features/trash/viewmodels/trash_view_model.dart';
+import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
+import 'package:swaralipi/shared/repositories/instrument_repository.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+import 'package:swaralipi/shared/repositories/tag_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+import 'package:swaralipi/features/capture/data/notation_repository_impl.dart';
+
+// ---------------------------------------------------------------------------
+// SwaralipiApp
+// ---------------------------------------------------------------------------
+
+/// Root widget for the Swaralipi application.
+///
+/// In production, constructed with no arguments — repositories are created
+/// internally from [AppDatabase] and [FileStorageService].
+///
+/// In tests, use [SwaralipiApp.forTesting] to inject fake repositories and
+/// control [initialLocation].
+class SwaralipiApp extends StatefulWidget {
+  /// Creates the production [SwaralipiApp].
+  ///
+  /// Builds all real repositories from [AppDatabase] and
+  /// [FileStorageService] opened via platform channels.
+  const SwaralipiApp({super.key})
+      : _initialLocation = '/',
+        _tagRepository = null,
+        _trashRepository = null,
+        _instrumentRepository = null,
+        _customFieldRepository = null,
+        _preferencesRepository = null,
+        _notationRepository = null,
+        _forTesting = false;
+
+  /// Creates a [SwaralipiApp] with injected repositories for integration tests.
+  ///
+  /// Parameters:
+  /// - [initialLocation]: The route the router starts at. Defaults to `'/'`.
+  /// - [tagRepository]: Fake [TagRepository] for testing.
+  /// - [trashRepository]: Fake [TrashRepository] for testing.
+  /// - [instrumentRepository]: Fake [InstrumentRepository] for testing.
+  /// - [customFieldRepository]: Fake [CustomFieldRepository] for testing.
+  /// - [preferencesRepository]: Fake [PreferencesRepository] for testing.
+  /// - [notationRepository]: Fake [NotationRepository] for testing.
+  const SwaralipiApp.forTesting({
+    super.key,
+    String initialLocation = '/',
+    required TagRepository tagRepository,
+    required TrashRepository trashRepository,
+    required InstrumentRepository instrumentRepository,
+    required CustomFieldRepository customFieldRepository,
+    required PreferencesRepository preferencesRepository,
+    NotationRepository? notationRepository,
+  })  : _initialLocation = initialLocation,
+        _tagRepository = tagRepository,
+        _trashRepository = trashRepository,
+        _instrumentRepository = instrumentRepository,
+        _customFieldRepository = customFieldRepository,
+        _preferencesRepository = preferencesRepository,
+        _notationRepository = notationRepository,
+        _forTesting = true;
+
+  final String _initialLocation;
+  final TagRepository? _tagRepository;
+  final TrashRepository? _trashRepository;
+  final InstrumentRepository? _instrumentRepository;
+  final CustomFieldRepository? _customFieldRepository;
+  final PreferencesRepository? _preferencesRepository;
+  final NotationRepository? _notationRepository;
+  final bool _forTesting;
+
+  @override
+  State<SwaralipiApp> createState() => _SwaralipiAppState();
+}
+
+class _SwaralipiAppState extends State<SwaralipiApp> {
+  late final AppDatabase? _db;
+  late final FileStorageService? _storageService;
+  late final TagRepository _tagRepository;
+  late final TrashRepository _trashRepository;
+  late final InstrumentRepository _instrumentRepository;
+  late final CustomFieldRepository _customFieldRepository;
+  late final PreferencesRepository _preferencesRepository;
+  late final NotationRepository? _notationRepository;
+  late final GoRouter _router;
+
+  @override
+  void initState() {
+    super.initState();
+    _initDependencies();
+    _router = _buildRouter();
+  }
+
+  void _initDependencies() {
+    if (widget._forTesting) {
+      _db = null;
+      _storageService = null;
+      _tagRepository = widget._tagRepository!;
+      _trashRepository = widget._trashRepository!;
+      _instrumentRepository = widget._instrumentRepository!;
+      _customFieldRepository = widget._customFieldRepository!;
+      _preferencesRepository = widget._preferencesRepository!;
+      _notationRepository = widget._notationRepository;
+    } else {
+      final db = AppDatabase();
+      final storageService = FileStorageService();
+      _db = db;
+      _storageService = storageService;
+
+      final prefsRepo = UserPreferencesRepositoryImpl(db.userPreferencesDao);
+      _preferencesRepository = prefsRepo;
+      _tagRepository = TagRepositoryImpl(db.tagDao, prefsRepo);
+      _trashRepository = TrashRepositoryImpl(db.notationDao, storageService);
+      _instrumentRepository = InstrumentRepositoryImpl(db.instrumentDao);
+      _customFieldRepository = CustomFieldRepositoryImpl(db.customFieldDao);
+      _notationRepository = NotationRepositoryImpl(
+        db.notationDao,
+        db.notationPageDao,
+        db.notationTagDao,
+        db.customFieldDao,
+      );
+    }
+  }
+
+  GoRouter _buildRouter() {
+    return GoRouter(
+      initialLocation: widget._initialLocation,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) {
+            final notationRepo = _notationRepository;
+            if (notationRepo == null) {
+              // Notation repository not provided — render empty placeholder.
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+            return ChangeNotifierProvider<LibraryViewModel>(
+              create: (_) => LibraryViewModel(
+                notationRepo,
+                _trashRepository,
+                tagRepository: _tagRepository,
+              )..init(),
+              child: LibraryScreen(
+                notationRepository: notationRepo,
+                tagRepository: _tagRepository,
+                instrumentRepository: _instrumentRepository,
+                customFieldRepository: _customFieldRepository,
+                fileStorageService: _storageService,
+                onNotationTap: (id) => context.go('/notation/$id'),
+              ),
+            );
+          },
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) => const SettingsScreen(),
+          routes: [
+            GoRoute(
+              path: 'tags',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<TagsViewModel>(
+                create: (_) => TagsViewModel(_tagRepository)..init(),
+                child: const TagsScreen(),
+              ),
+            ),
+            GoRoute(
+              path: 'instruments',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<InstrumentClassesViewModel>(
+                create: (_) =>
+                    InstrumentClassesViewModel(_instrumentRepository)..init(),
+                child: const InstrumentClassesScreen(),
+              ),
+            ),
+            GoRoute(
+              path: 'trash',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<TrashViewModel>(
+                create: (_) => TrashViewModel(_trashRepository)..init(),
+                child: const TrashScreen(),
+              ),
+            ),
+            GoRoute(
+              path: 'appearance',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<AppearanceViewModel>(
+                create: (_) =>
+                    AppearanceViewModel(_preferencesRepository)..init(),
+                child: const AppearanceScreen(),
+              ),
+            ),
+            GoRoute(
+              path: 'custom-fields',
+              builder: (context, state) =>
+                  ChangeNotifierProvider<CustomFieldsViewModel>(
+                create: (_) =>
+                    CustomFieldsViewModel(_customFieldRepository)..init(),
+                child: const CustomFieldsScreen(),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _router.dispose();
+    _db?.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'Swaralipi',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF6750A4),
+        ),
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF6750A4),
+          brightness: Brightness.dark,
+        ),
+      ),
+      routerConfig: _router,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,15 +15,18 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 
+import 'package:swaralipi/app.dart';
 import 'package:swaralipi/core/database/app_database.dart';
 import 'package:swaralipi/core/storage/file_storage_service.dart';
 
 /// Application entry point.
 ///
 /// Calls [WidgetsFlutterBinding.ensureInitialized] before any platform channel
-/// work, then opens the database, and finally launches the UI. The orphan
-/// cleanup runs as an unawaited background task so it does not delay first
-/// frame rendering.
+/// work, opens the database for orphan cleanup, then launches the UI.
+/// The orphan cleanup runs as an unawaited background task so it does not delay
+/// first frame rendering.
+///
+/// All repository wiring happens inside [SwaralipiApp].
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -72,50 +75,6 @@ Future<void> _runOrphanCleanup(
       name: 'OrphanCleanup',
       error: e,
       stackTrace: st,
-    );
-  }
-}
-
-/// Root widget for the Swaralipi application.
-class SwaralipiApp extends StatelessWidget {
-  /// Creates the [SwaralipiApp].
-  const SwaralipiApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Swaralipi',
-      theme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF6750A4),
-        ),
-      ),
-      darkTheme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF6750A4),
-          brightness: Brightness.dark,
-        ),
-      ),
-      home: const _PlaceholderHome(),
-    );
-  }
-}
-
-/// Placeholder home screen used until the real navigation shell is implemented.
-class _PlaceholderHome extends StatelessWidget {
-  const _PlaceholderHome();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Swaralipi'),
-      ),
-      body: const Center(
-        child: Text('App under construction'),
-      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.4.12
   json_serializable: ^6.8.0


### PR DESCRIPTION
## Linked Issue

Closes #100

## Summary

- Extracts `SwaralipiApp` into `lib/app.dart` with a `SwaralipiApp.forTesting` named constructor that accepts injected fake repositories and an `initialLocation`, enabling integration tests to exercise the real GoRouter configuration without hitting the platform database.
- Wires all 5 Settings sub-routes (`/settings/tags`, `/settings/instruments`, `/settings/trash`, `/settings/appearance`, `/settings/custom-fields`) into the GoRouter route tree, each with a `ChangeNotifierProvider`-scoped ViewModel.
- Adds integration tests covering all 5 sub-route navigations, back-navigation to the Settings shell, and direct deep-link navigation to `/settings/tags`.

## Type of Change

- `feat` — new behaviour (Settings navigation integration)
- `test` — integration tests for navigation flows

## Commit Convention

`feat(settings): wire all Settings sub-routes into GoRouter (#100)`

## Test Plan

- [x] `integration_test/settings/settings_navigation_test.dart` — 7 integration tests covering:
  - Tags tile navigates to `TagsScreen`
  - Instruments tile navigates to `InstrumentClassesScreen`
  - Trash tile navigates to `TrashScreen`
  - Appearance tile navigates to `AppearanceScreen`
  - Custom Fields tile navigates to `CustomFieldsScreen`
  - Back navigation from Tags sub-screen returns to `SettingsScreen`
  - Deep-link directly to `/settings/tags` does not crash
- [x] All 987 existing unit tests continue to pass
- [x] `dart format` — 0 changed files
- [x] `flutter analyze` — 0 errors in touched files; pre-existing warnings in unrelated files only

## Checklist

- [x] All tests pass
- [x] `dart format` passes (line length 80)
- [x] `flutter analyze` — zero errors in files touched by this PR
- [x] Code review: no CRITICAL or HIGH issues
- [x] PR opened and linked to issue #100