### PR TITLE
fix: capture flow, greeting default, reactive theme (#tasks)

### DIFF
--- a/integration_test/settings/settings_navigation_test.dart
+++ b/integration_test/settings/settings_navigation_test.dart
@@ -193,6 +193,14 @@ class _FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateTagsSeeded({required bool value}) async {
     _prefs = _prefs.copyWith(tagsSeeded: value);
   }
+
+  @override
+  Future<void> updateUserName(String name) async {
+    _prefs = _prefs.copyWith(userName: name);
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(_prefs);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -16,6 +16,9 @@
 //     /settings/appearance     → AppearanceScreen
 //     /settings/custom-fields  → CustomFieldsScreen
 
+import 'dart:async';
+
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -24,7 +27,10 @@ import 'package:swaralipi/core/database/app_database.dart';
 import 'package:swaralipi/core/storage/file_storage_service.dart';
 import 'package:swaralipi/features/capture/data/camera_service.dart';
 import 'package:swaralipi/features/capture/screens/capture_entry_sheet.dart';
+import 'package:swaralipi/features/capture/screens/page_editor_screen.dart';
 import 'package:swaralipi/features/capture/viewmodels/capture_entry_view_model.dart';
+import 'package:swaralipi/features/capture/viewmodels/capture_session_view_model.dart';
+import 'package:swaralipi/features/capture/viewmodels/page_editor_view_model.dart';
 import 'package:swaralipi/features/custom_fields/data/custom_field_repository_impl.dart';
 import 'package:swaralipi/features/custom_fields/screens/custom_fields_screen.dart';
 import 'package:swaralipi/features/custom_fields/viewmodels/custom_fields_view_model.dart';
@@ -46,6 +52,7 @@ import 'package:swaralipi/features/trash/viewmodels/trash_view_model.dart';
 import 'package:swaralipi/shared/repositories/custom_field_repository.dart';
 import 'package:swaralipi/shared/repositories/instrument_repository.dart';
 import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
 import 'package:swaralipi/shared/repositories/preferences_repository.dart';
 import 'package:swaralipi/shared/repositories/tag_repository.dart';
 import 'package:swaralipi/shared/repositories/trash_repository.dart';
@@ -139,11 +146,32 @@ class _SwaralipiAppState extends State<SwaralipiApp> {
   late final NotationRepository? _notationRepository;
   late final GoRouter _router;
 
+  /// Live preferences value driving [MaterialApp] theme and themeMode.
+  late final ValueNotifier<UserPreferences?> _prefsNotifier;
+
+  StreamSubscription<UserPreferences>? _prefsSub;
+
   @override
   void initState() {
     super.initState();
     _initDependencies();
     _router = _buildRouter();
+    _prefsNotifier = ValueNotifier<UserPreferences?>(null);
+    _subscribeToPreferences();
+  }
+
+  /// Seeds the singleton row then subscribes to live preference changes.
+  ///
+  /// The first [getPreferences] call ensures the row exists so that
+  /// [watchPreferences] emits immediately.
+  Future<void> _subscribeToPreferences() async {
+    // Seed the row so watchPreferences has something to emit.
+    final initial = await _preferencesRepository.getPreferences();
+    if (!mounted) return;
+    _prefsNotifier.value = initial;
+    _prefsSub = _preferencesRepository.watchPreferences().listen((prefs) {
+      _prefsNotifier.value = prefs;
+    });
   }
 
   void _initDependencies() {
@@ -279,30 +307,88 @@ class _SwaralipiAppState extends State<SwaralipiApp> {
 
   @override
   void dispose() {
+    _prefsSub?.cancel();
+    _prefsNotifier.dispose();
     _router.dispose();
     _db?.close();
     super.dispose();
   }
 
+  /// Default seed color used when Monet is unavailable and no seed is stored.
+  static const Color _kDefaultSeed = Color(0xFF6750A4);
+
+  /// Builds a [ThemeData] from a [ColorScheme].
+  ThemeData _buildTheme(ColorScheme scheme) =>
+      ThemeData(useMaterial3: true, colorScheme: scheme);
+
+  /// Resolves the live [ThemeMode] from stored [AppThemeMode].
+  ThemeMode _resolveThemeMode(AppThemeMode mode) => switch (mode) {
+        AppThemeMode.light => ThemeMode.light,
+        AppThemeMode.dark => ThemeMode.dark,
+        AppThemeMode.system => ThemeMode.system,
+      };
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'Swaralipi',
-      theme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF6750A4),
-        ),
-      ),
-      darkTheme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF6750A4),
-          brightness: Brightness.dark,
-        ),
-      ),
-      routerConfig: _router,
+    return DynamicColorBuilder(
+      builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+        return ValueListenableBuilder<UserPreferences?>(
+          valueListenable: _prefsNotifier,
+          builder: (_, prefs, __) {
+            final ColorScheme lightScheme;
+            final ColorScheme darkScheme;
+            final ThemeMode themeMode;
+
+            if (prefs == null) {
+              // Preferences not yet loaded — use defaults.
+              lightScheme = ColorScheme.fromSeed(seedColor: _kDefaultSeed);
+              darkScheme = ColorScheme.fromSeed(
+                seedColor: _kDefaultSeed,
+                brightness: Brightness.dark,
+              );
+              themeMode = ThemeMode.system;
+            } else {
+              themeMode = _resolveThemeMode(prefs.themeMode);
+
+              final useMonet = prefs.colorSchemeMode == ColorSchemeMode.monet;
+              if (useMonet && lightDynamic != null && darkDynamic != null) {
+                lightScheme = lightDynamic.harmonized();
+                darkScheme = darkDynamic.harmonized();
+              } else {
+                // Parse stored hex seed or fall back to default.
+                final seed = _parseSeedColor(prefs.seedColor) ?? _kDefaultSeed;
+                lightScheme = ColorScheme.fromSeed(seedColor: seed);
+                darkScheme = ColorScheme.fromSeed(
+                  seedColor: seed,
+                  brightness: Brightness.dark,
+                );
+              }
+            }
+
+            return MaterialApp.router(
+              title: 'Swaralipi',
+              theme: _buildTheme(lightScheme),
+              darkTheme: _buildTheme(darkScheme),
+              themeMode: themeMode,
+              routerConfig: _router,
+            );
+          },
+        );
+      },
     );
+  }
+
+  /// Parses a hex color string (e.g. `'#f38ba8'` or `'0xFFf38ba8'`) into a
+  /// [Color], returning `null` when the string is null or unparseable.
+  ///
+  /// Parameters:
+  /// - [hex]: A CSS-style `#RRGGBB` or Dart-style `0xAARRGGBB` hex string.
+  static Color? _parseSeedColor(String? hex) {
+    if (hex == null || hex.isEmpty) return null;
+    final normalized = hex.replaceFirst('#', '0xFF');
+    final value = int.tryParse(normalized);
+    if (value == null) return null;
+    return Color(value);
   }
 }
 
@@ -388,12 +474,47 @@ class _AppShell extends StatelessWidget {
     }
   }
 
-  void _openCaptureSheet(BuildContext context) {
-    showModalBottomSheet<void>(
+  /// Opens the capture-entry bottom sheet and, when paths are returned,
+  /// navigates to [PageEditorScreen].
+  ///
+  /// The sheet pops with `List<String>` when the user completes a camera or
+  /// gallery capture. An empty or null result closes the sheet silently.
+  Future<void> _openCaptureSheet(BuildContext context) async {
+    final paths = await showModalBottomSheet<List<String>>(
       context: context,
       builder: (_) => ChangeNotifierProvider<CaptureEntryViewModel>(
         create: (_) => CaptureEntryViewModel(CameraServiceImpl()),
         child: const CaptureEntrySheet(),
+      ),
+    );
+
+    if (paths == null || paths.isEmpty) return;
+    if (!context.mounted) return;
+
+    final session = CaptureSessionViewModel();
+    await session.loadFromPaths(paths);
+
+    if (!context.mounted) return;
+
+    final pageEditorVm = PageEditorViewModel(session: session);
+
+    unawaited(
+      Navigator.of(context).push<void>(
+        MaterialPageRoute<void>(
+          builder: (_) => MultiProvider(
+            providers: [
+              ChangeNotifierProvider<CaptureSessionViewModel>.value(
+                value: session,
+              ),
+              ChangeNotifierProvider<PageEditorViewModel>.value(
+                value: pageEditorVm,
+              ),
+            ],
+            child: PageEditorScreen(
+              onNext: (_) {},
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -408,7 +529,7 @@ class _AppShell extends StatelessWidget {
           ? Semantics(
               label: 'Capture new notation',
               child: FloatingActionButton.extended(
-                onPressed: () => _openCaptureSheet(context),
+                onPressed: () => unawaited(_openCaptureSheet(context)),
                 backgroundColor: colorScheme.primaryContainer,
                 foregroundColor: colorScheme.onPrimaryContainer,
                 icon: const Icon(Icons.add_a_photo_outlined),

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -381,7 +381,9 @@ class UserPreferencesTable extends Table {
   IntColumn get id => integer().withDefault(const Constant(1))();
 
   /// Display name shown in the app.
-  TextColumn get userName => text().withDefault(const Constant('Musician'))();
+  ///
+  /// Defaults to empty string so the first-launch name dialog is triggered.
+  TextColumn get userName => text().withDefault(const Constant(''))();
 
   /// Theme mode: `'light'`, `'dark'`, or `'system'`.
   TextColumn get themeMode => text().withDefault(const Constant('system'))();
@@ -470,6 +472,7 @@ class UserPreferencesTable extends Table {
 /// | 3 | Add `deleted_at` column to `instrument_classes_table` |
 /// | 4 | Add `player_orientation` column to `user_preferences_table` |
 /// | 5 | Add `auto_scroll_speed` column to `user_preferences_table` |
+/// | 6 | Clear `user_name = 'Musician'` rows; first-launch dialog supplies name |
 @DriftDatabase(
   tables: [
     NotationsTable,
@@ -538,7 +541,7 @@ class AppDatabase extends _$AppDatabase {
         );
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -578,6 +581,14 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(
               userPreferencesTable,
               userPreferencesTable.autoScrollSpeed,
+            );
+          }
+          // v5 → v6: clear any existing 'Musician' default userName so the
+          // first-launch name dialog is shown to existing users.
+          if (from < 6) {
+            await customStatement(
+              "UPDATE user_preferences_table SET user_name = '' "
+              "WHERE user_name = 'Musician'",
             );
           }
         },

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -3407,7 +3407,7 @@ class $UserPreferencesTableTable extends UserPreferencesTable
       'user_name', aliasedName, false,
       type: DriftSqlType.string,
       requiredDuringInsert: false,
-      defaultValue: const Constant('Musician'));
+      defaultValue: const Constant(''));
   static const VerificationMeta _themeModeMeta =
       const VerificationMeta('themeMode');
   @override
@@ -3591,6 +3591,8 @@ class UserPreferencesRow extends DataClass
   final int id;
 
   /// Display name shown in the app.
+  ///
+  /// Defaults to empty string so the first-launch name dialog is triggered.
   final String userName;
 
   /// Theme mode: `'light'`, `'dark'`, or `'system'`.

--- a/lib/core/database/daos/user_preferences_dao.dart
+++ b/lib/core/database/daos/user_preferences_dao.dart
@@ -65,6 +65,18 @@ class UserPreferencesDao extends DatabaseAccessor<AppDatabase>
         .getSingle();
   }
 
+  /// Returns a [Stream] that emits the singleton user preferences row whenever
+  /// it changes.
+  ///
+  /// The stream does not emit until the row exists. Callers should ensure
+  /// [getPreferences] has been called at least once before subscribing so the
+  /// default row is present.
+  Stream<UserPreferencesRow> watchPreferences() {
+    return (select(userPreferencesTable)
+          ..where((t) => t.id.equals(_kSingletonId)))
+        .watchSingle();
+  }
+
   // -------------------------------------------------------------------------
   // Write operations
   // -------------------------------------------------------------------------

--- a/lib/features/capture/data/camera_service.dart
+++ b/lib/features/capture/data/camera_service.dart
@@ -1,5 +1,5 @@
 // camera_service.dart — abstraction over camera permission, intent launch,
-// MediaStore query, and gallery picker.
+// and gallery picker.
 //
 // The concrete implementation [CameraServiceImpl] uses:
 //   - permission_handler for runtime camera permission
@@ -7,9 +7,13 @@
 //
 // The abstract [CameraService] interface is kept separate so that unit tests
 // can substitute a [FakeCameraService] without platform dependencies.
+//
+// Change from initial design: [launchCamera] now returns the captured image
+// path directly (Task 2 fix). The defunct
+// [queryMediaStoreAfterTimestamp] has been removed — it opened the gallery
+// picker a second time, which was the original bug.
 
 import 'dart:developer';
-import 'dart:io';
 
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -44,17 +48,9 @@ abstract interface class CameraService {
 
   /// Launches the device camera activity via an intent.
   ///
-  /// Returns after the user presses back / exits the camera app.
-  Future<void> launchCamera();
-
-  /// Queries the device MediaStore for images added on or after [timestamp].
-  ///
-  /// Returns a list of absolute file paths sorted by recency (newest first).
-  ///
-  /// Parameters:
-  /// - [timestamp]: The lower bound for `date_added`; typically recorded just
-  ///   before [launchCamera] is called.
-  Future<List<String>> queryMediaStoreAfterTimestamp(DateTime timestamp);
+  /// Returns the absolute file path of the captured image, or `null` when the
+  /// user cancels without taking a photo.
+  Future<String?> launchCamera();
 
   /// Opens the system gallery picker and returns selected image paths.
   ///
@@ -69,9 +65,8 @@ abstract interface class CameraService {
 /// Production implementation of [CameraService] backed by [ImagePicker] and
 /// [permission_handler].
 ///
-/// MediaStore querying is performed by scanning images returned from the
-/// picker using a timestamp filter, since direct ContentResolver queries are
-/// not available in Dart without platform channels.
+/// [launchCamera] uses `pickImage(source: ImageSource.camera)` and returns the
+/// captured file path directly — no secondary gallery picker is needed.
 class CameraServiceImpl implements CameraService {
   /// Creates a [CameraServiceImpl].
   ///
@@ -97,12 +92,13 @@ class CameraServiceImpl implements CameraService {
   }
 
   @override
-  Future<void> launchCamera() async {
+  Future<String?> launchCamera() async {
     // image_picker uses ACTION_IMAGE_CAPTURE intent on Android.
-    // We ignore the returned XFile here; results are fetched via
-    // queryMediaStoreAfterTimestamp so multi-photo sessions are supported.
+    // Returns the XFile path directly so callers do not need a second
+    // gallery-picker round-trip (which was the original bug).
     try {
-      await _picker.pickImage(source: ImageSource.camera);
+      final xFile = await _picker.pickImage(source: ImageSource.camera);
+      return xFile?.path;
     } on Exception catch (e, st) {
       log(
         'CameraServiceImpl.launchCamera failed: $e',
@@ -110,39 +106,7 @@ class CameraServiceImpl implements CameraService {
         error: e,
         stackTrace: st,
       );
-    }
-  }
-
-  @override
-  Future<List<String>> queryMediaStoreAfterTimestamp(
-    DateTime timestamp,
-  ) async {
-    // image_picker does not provide a MediaStore query API.
-    // We use the image_picker gallery picker restricted to images and sort by
-    // last-modified date, then filter by timestamp ourselves.
-    //
-    // Limitation: only images visible in the picker are returned. This covers
-    // the Samsung Galaxy S25 DCIM folder reliably.
-    try {
-      final images = await _picker.pickMultiImage();
-      final paths = <String>[];
-      for (final xFile in images) {
-        final file = File(xFile.path);
-        if (!file.existsSync()) continue;
-        final stat = file.statSync();
-        if (!stat.modified.isBefore(timestamp)) {
-          paths.add(xFile.path);
-        }
-      }
-      return paths;
-    } on Exception catch (e, st) {
-      log(
-        'CameraServiceImpl.queryMediaStoreAfterTimestamp failed: $e',
-        name: 'CameraService',
-        error: e,
-        stackTrace: st,
-      );
-      return [];
+      return null;
     }
   }
 

--- a/lib/features/capture/viewmodels/capture_entry_view_model.dart
+++ b/lib/features/capture/viewmodels/capture_entry_view_model.dart
@@ -2,7 +2,7 @@
 // entry sheet.
 //
 // Manages the camera permission request flow, device camera intent launch,
-// MediaStore timestamp query, and gallery picker delegation.
+// and gallery picker delegation.
 //
 // State hierarchy (sealed):
 //   CaptureEntryStateIdle                — initial, no operation in progress
@@ -113,8 +113,8 @@ class CaptureEntryViewModel extends ChangeNotifier {
 
   /// Requests the CAMERA permission, then launches the device camera.
   ///
-  /// On return from the camera, queries MediaStore for images added on or after
-  /// the timestamp recorded just before the launch.
+  /// The returned path from [CameraService.launchCamera] is used directly —
+  /// no secondary gallery query is needed.
   ///
   /// State transitions:
   ///   idle → loading → permissionDenied | permissionPermanentlyDenied |
@@ -135,10 +135,9 @@ class CaptureEntryViewModel extends ChangeNotifier {
         break;
     }
 
-    final launchTimestamp = DateTime.now();
-
+    final String? path;
     try {
-      await _cameraService.launchCamera();
+      path = await _cameraService.launchCamera();
     } on Exception catch (e, st) {
       log(
         'CaptureEntryViewModel: camera launch error: $e',
@@ -150,14 +149,10 @@ class CaptureEntryViewModel extends ChangeNotifier {
       return;
     }
 
-    final imagePaths = await _cameraService.queryMediaStoreAfterTimestamp(
-      launchTimestamp,
-    );
-
-    if (imagePaths.isEmpty) {
+    if (path == null) {
       _setState(const CaptureEntryStateCameraEmpty());
     } else {
-      _setState(CaptureEntryStateCameraDone(imagePaths));
+      _setState(CaptureEntryStateCameraDone([path]));
     }
   }
 

--- a/lib/features/library/screens/library_screen.dart
+++ b/lib/features/library/screens/library_screen.dart
@@ -166,9 +166,40 @@ class _LibraryScreenState extends State<LibraryScreen> {
     final prefs = await repo.getPreferences();
     if (!mounted) return;
     final name = prefs.userName.trim();
+    if (name.isEmpty) {
+      await _promptForName(repo);
+      return;
+    }
     setState(() {
-      _greeting = name.isEmpty ? 'Hi there' : 'Hi, $name';
+      _greeting = 'Hi, $name';
     });
+  }
+
+  /// Shows a blocking dialog that asks the user for their name on first launch.
+  ///
+  /// The dialog cannot be dismissed without entering a name. On save, persists
+  /// the name via [repo] and updates the greeting immediately.
+  ///
+  /// Parameters:
+  /// - [repo]: The [PreferencesRepository] used to persist the entered name.
+  Future<void> _promptForName(PreferencesRepository repo) async {
+    final controller = TextEditingController();
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => _NamePromptDialog(
+        controller: controller,
+        onSave: (name) async {
+          Navigator.of(dialogContext).pop();
+          await repo.updateUserName(name);
+          if (!mounted) return;
+          setState(() {
+            _greeting = 'Hi, $name';
+          });
+        },
+      ),
+    );
+    controller.dispose();
   }
 
   @override
@@ -705,6 +736,85 @@ class _SwipeDeleteBackground extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _NamePromptDialog
+// ---------------------------------------------------------------------------
+
+/// Blocking first-launch dialog that asks the user for their display name.
+///
+/// The dialog cannot be dismissed without entering a non-empty name. The
+/// [FilledButton] is disabled while the text field is empty. On save, [onSave]
+/// is called with the trimmed name.
+class _NamePromptDialog extends StatefulWidget {
+  /// Creates a [_NamePromptDialog].
+  ///
+  /// Parameters:
+  /// - [controller]: The [TextEditingController] for the name input.
+  /// - [onSave]: Called with the trimmed name when the user taps "Save".
+  const _NamePromptDialog({
+    required this.controller,
+    required this.onSave,
+  });
+
+  /// Shared controller so the caller can dispose after the dialog closes.
+  final TextEditingController controller;
+
+  /// Invoked with the trimmed, non-empty name on save.
+  final void Function(String name) onSave;
+
+  @override
+  State<_NamePromptDialog> createState() => _NamePromptDialogState();
+}
+
+class _NamePromptDialogState extends State<_NamePromptDialog> {
+  bool _isEmpty = true;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    final empty = widget.controller.text.trim().isEmpty;
+    if (empty != _isEmpty) {
+      setState(() => _isEmpty = empty);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTextChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("What's your name?"),
+      content: TextField(
+        controller: widget.controller,
+        autofocus: true,
+        textInputAction: TextInputAction.done,
+        onSubmitted: _isEmpty
+            ? null
+            : (_) => widget.onSave(widget.controller.text.trim()),
+        decoration: const InputDecoration(
+          hintText: 'Enter your name',
+        ),
+      ),
+      actions: [
+        FilledButton(
+          onPressed: _isEmpty
+              ? null
+              : () => widget.onSave(widget.controller.text.trim()),
+          child: const Text('Save'),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/library/screens/library_screen.dart
+++ b/lib/features/library/screens/library_screen.dart
@@ -183,23 +183,21 @@ class _LibraryScreenState extends State<LibraryScreen> {
   /// Parameters:
   /// - [repo]: The [PreferencesRepository] used to persist the entered name.
   Future<void> _promptForName(PreferencesRepository repo) async {
-    final controller = TextEditingController();
-    await showDialog<void>(
+    // showDialog<String?> — the dialog pops with the entered name so this
+    // method never touches the internal TextEditingController (which the dialog
+    // owns and disposes itself).
+    final name = await showDialog<String>(
       context: context,
       barrierDismissible: false,
-      builder: (dialogContext) => _NamePromptDialog(
-        controller: controller,
-        onSave: (name) async {
-          Navigator.of(dialogContext).pop();
-          await repo.updateUserName(name);
-          if (!mounted) return;
-          setState(() {
-            _greeting = 'Hi, $name';
-          });
-        },
-      ),
+      builder: (_) => const _NamePromptDialog(),
     );
-    controller.dispose();
+
+    if (name == null || name.isEmpty) return;
+    await repo.updateUserName(name);
+    if (!mounted) return;
+    setState(() {
+      _greeting = 'Hi, $name';
+    });
   }
 
   @override
@@ -747,40 +745,31 @@ class _SwipeDeleteBackground extends StatelessWidget {
 /// Blocking first-launch dialog that asks the user for their display name.
 ///
 /// The dialog cannot be dismissed without entering a non-empty name. The
-/// [FilledButton] is disabled while the text field is empty. On save, [onSave]
-/// is called with the trimmed name.
+/// [FilledButton] is disabled while the text field is empty. When the user
+/// taps "Save", the dialog pops with the trimmed name as the result.
+///
+/// The [TextEditingController] is owned and disposed by this widget.
 class _NamePromptDialog extends StatefulWidget {
   /// Creates a [_NamePromptDialog].
-  ///
-  /// Parameters:
-  /// - [controller]: The [TextEditingController] for the name input.
-  /// - [onSave]: Called with the trimmed name when the user taps "Save".
-  const _NamePromptDialog({
-    required this.controller,
-    required this.onSave,
-  });
-
-  /// Shared controller so the caller can dispose after the dialog closes.
-  final TextEditingController controller;
-
-  /// Invoked with the trimmed, non-empty name on save.
-  final void Function(String name) onSave;
+  const _NamePromptDialog();
 
   @override
   State<_NamePromptDialog> createState() => _NamePromptDialogState();
 }
 
 class _NamePromptDialogState extends State<_NamePromptDialog> {
+  late final TextEditingController _controller;
   bool _isEmpty = true;
 
   @override
   void initState() {
     super.initState();
-    widget.controller.addListener(_onTextChanged);
+    _controller = TextEditingController();
+    _controller.addListener(_onTextChanged);
   }
 
   void _onTextChanged() {
-    final empty = widget.controller.text.trim().isEmpty;
+    final empty = _controller.text.trim().isEmpty;
     if (empty != _isEmpty) {
       setState(() => _isEmpty = empty);
     }
@@ -788,8 +777,13 @@ class _NamePromptDialogState extends State<_NamePromptDialog> {
 
   @override
   void dispose() {
-    widget.controller.removeListener(_onTextChanged);
+    _controller.removeListener(_onTextChanged);
+    _controller.dispose();
     super.dispose();
+  }
+
+  void _save() {
+    Navigator.of(context).pop(_controller.text.trim());
   }
 
   @override
@@ -797,21 +791,17 @@ class _NamePromptDialogState extends State<_NamePromptDialog> {
     return AlertDialog(
       title: const Text("What's your name?"),
       content: TextField(
-        controller: widget.controller,
+        controller: _controller,
         autofocus: true,
         textInputAction: TextInputAction.done,
-        onSubmitted: _isEmpty
-            ? null
-            : (_) => widget.onSave(widget.controller.text.trim()),
+        onSubmitted: _isEmpty ? null : (_) => _save(),
         decoration: const InputDecoration(
           hintText: 'Enter your name',
         ),
       ),
       actions: [
         FilledButton(
-          onPressed: _isEmpty
-              ? null
-              : () => widget.onSave(widget.controller.text.trim()),
+          onPressed: _isEmpty ? null : _save,
           child: const Text('Save'),
         ),
       ],

--- a/lib/features/notation_detail/screens/notation_detail_screen.dart
+++ b/lib/features/notation_detail/screens/notation_detail_screen.dart
@@ -821,4 +821,10 @@ final class _NoOpPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() => const Stream.empty();
 }

--- a/lib/features/settings/data/user_preferences_repository_impl.dart
+++ b/lib/features/settings/data/user_preferences_repository_impl.dart
@@ -59,6 +59,11 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
   }
 
   @override
+  Stream<UserPreferences> watchPreferences() {
+    return _dao.watchPreferences().map(_rowToPreferences);
+  }
+
+  @override
   Future<void> updatePreferences(UserPreferences preferences) async {
     await _dao.upsertPreferences(
       UserPreferencesTableCompanion(
@@ -185,6 +190,29 @@ final class UserPreferencesRepositoryImpl implements PreferencesRepository {
     );
     log(
       'UserPreferencesRepositoryImpl: autoScrollSpeed set to $speed',
+      name: 'UserPreferencesRepository',
+    );
+  }
+
+  @override
+  Future<void> updateUserName(String name) async {
+    final existing = await _dao.getPreferences();
+    await _dao.upsertPreferences(
+      UserPreferencesTableCompanion(
+        id: const Value(_kSingletonId),
+        userName: Value(name),
+        themeMode: Value(existing.themeMode),
+        colorSchemeMode: Value(existing.colorSchemeMode),
+        seedColor: Value(existing.seedColor),
+        defaultSort: Value(existing.defaultSort),
+        defaultView: Value(existing.defaultView),
+        tagsSeeded: Value(existing.tagsSeeded),
+        playerOrientation: Value(existing.playerOrientation),
+        autoScrollSpeed: Value(existing.autoScrollSpeed),
+      ),
+    );
+    log(
+      'UserPreferencesRepositoryImpl: userName set to $name',
       name: 'UserPreferencesRepository',
     );
   }

--- a/lib/shared/repositories/preferences_repository.dart
+++ b/lib/shared/repositories/preferences_repository.dart
@@ -23,6 +23,13 @@ abstract interface class PreferencesRepository
   @override
   Future<UserPreferences> getPreferences();
 
+  /// Returns a [Stream] that emits the current [UserPreferences] and re-emits
+  /// whenever any preference field is updated.
+  ///
+  /// Callers must ensure [getPreferences] has been called once before
+  /// subscribing so the singleton row exists in the database.
+  Stream<UserPreferences> watchPreferences();
+
   /// Persists a complete [UserPreferences] value.
   ///
   /// Parameters:
@@ -71,6 +78,14 @@ abstract interface class PreferencesRepository
   /// Parameters:
   /// - [speed]: The new auto-scroll speed multiplier to persist.
   Future<void> updateAutoScrollSpeed(double speed);
+
+  /// Updates the `user_name` field to [name].
+  ///
+  /// All other preference fields are left unchanged.
+  ///
+  /// Parameters:
+  /// - [name]: The new display name to persist. An empty string is allowed.
+  Future<void> updateUserName(String name);
 
   /// Convenience method to flip the `tagsSeeded` flag.
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   uuid: ^4.5.3
   permission_handler: ^12.0.1
   package_info_plus: ^10.1.0
+  dynamic_color: ^1.8.1
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/core/database/daos/user_preferences_dao_test.dart
+++ b/test/unit/core/database/daos/user_preferences_dao_test.dart
@@ -36,7 +36,7 @@ void main() {
 
       expect(prefs, isNotNull);
       expect(prefs.id, 1);
-      expect(prefs.userName, 'Musician');
+      expect(prefs.userName, '');
       expect(prefs.themeMode, 'system');
       expect(prefs.colorSchemeMode, 'catppuccin');
       expect(prefs.seedColor, isNull);
@@ -52,7 +52,7 @@ void main() {
 
       final prefs = await dao.getPreferences();
       expect(prefs.id, 1);
-      expect(prefs.userName, 'Musician');
+      expect(prefs.userName, '');
     });
 
     test('calling getPreferences twice returns the same row', () async {

--- a/test/unit/core/database/migration_test.dart
+++ b/test/unit/core/database/migration_test.dart
@@ -1,4 +1,4 @@
-// Migration tests for AppDatabase — schema v5.
+// Migration tests for AppDatabase — schema v6.
 //
 // Verifies that [MigrationStrategy.onCreate] produces the exact schema
 // described in docs/02-technical/data-model.md, including:
@@ -6,7 +6,7 @@
 //   - All 9 indexes (partial and non-partial)
 //   - The FTS5 virtual table (notations_fts) and its 3 sync triggers
 //   - Seed data: 5 default tags and the singleton user_preferences row
-//   - schemaVersion == 5
+//   - schemaVersion == 6
 //
 // [validateDatabaseSchema] (from drift_dev/api/migrations_native.dart) is
 // used to compare the live schema against Drift's reference schema, giving
@@ -110,18 +110,18 @@ void main() {
   setUpAll(() => driftRuntimeOptions.dontWarnAboutMultipleDatabases = true);
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — schema version', () {
+  group('Migration v6 — schema version', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
 
-    test('schemaVersion is 5', () {
-      expect(db.schemaVersion, 5);
+    test('schemaVersion is 6', () {
+      expect(db.schemaVersion, 6);
     });
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — Drift schema validation', () {
+  group('Migration v6 — Drift schema validation', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -146,7 +146,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — table presence', () {
+  group('Migration v6 — table presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -160,7 +160,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — index presence', () {
+  group('Migration v6 — index presence', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -174,7 +174,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — FTS5 virtual table and triggers', () {
+  group('Migration v6 — FTS5 virtual table and triggers', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -219,7 +219,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — seed data', () {
+  group('Migration v6 — seed data', () {
     late AppDatabase db;
     setUp(() async => db = await _openSeeded());
     tearDown(() => db.close());
@@ -258,7 +258,7 @@ void main() {
       expect(prefs.colorSchemeMode, 'catppuccin');
       expect(prefs.defaultSort, 'created_at_desc');
       expect(prefs.defaultView, 'list');
-      expect(prefs.userName, 'Musician');
+      expect(prefs.userName, '');
       expect(prefs.tagsSeeded, 0);
       expect(prefs.playerOrientation, 'auto');
       expect(prefs.autoScrollSpeed, closeTo(1.0, 0.001));
@@ -266,7 +266,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  group('Migration v5 — forTesting mode has no seed data', () {
+  group('Migration v6 — forTesting mode has no seed data', () {
     late AppDatabase db;
     setUp(() {
       db = AppDatabase.forTesting();

--- a/test/unit/features/capture/capture_entry_view_model_test.dart
+++ b/test/unit/features/capture/capture_entry_view_model_test.dart
@@ -2,9 +2,9 @@
 //
 // Covers:
 //   - Permission states: granted, denied, permanentlyDenied
-//   - Camera launch: records launchTimestamp and fires camera via CameraService
-//   - MediaStore query: returns images after camera session
-//   - Empty result after camera session
+//   - Camera launch: returns path directly from launchCamera (Task 2 fix)
+//   - Non-null path → CaptureEntryStateCameraDone
+//   - Null path → CaptureEntryStateCameraEmpty
 //   - Gallery launch delegates to CameraService.pickFromGallery
 
 import 'package:flutter_test/flutter_test.dart';
@@ -24,17 +24,14 @@ class FakeCameraService implements CameraService {
   /// Whether [requestCameraPermission] should return permanently denied.
   bool permissionPermanentlyDenied = false;
 
-  /// Images returned by [queryMediaStoreAfterTimestamp].
-  List<String> mediaStoreImages = [];
+  /// Path returned by [launchCamera]; null simulates user cancellation.
+  String? cameraReturnPath;
 
   /// Images returned by [pickFromGallery].
   List<String> galleryImages = [];
 
   /// Whether [launchCamera] was called.
   bool cameraLaunched = false;
-
-  /// The timestamp passed to [queryMediaStoreAfterTimestamp].
-  DateTime? queriedTimestamp;
 
   @override
   Future<CameraPermissionStatus> requestCameraPermission() async {
@@ -46,16 +43,9 @@ class FakeCameraService implements CameraService {
   }
 
   @override
-  Future<void> launchCamera() async {
+  Future<String?> launchCamera() async {
     cameraLaunched = true;
-  }
-
-  @override
-  Future<List<String>> queryMediaStoreAfterTimestamp(
-    DateTime timestamp,
-  ) async {
-    queriedTimestamp = timestamp;
-    return mediaStoreImages;
+    return cameraReturnPath;
   }
 
   @override
@@ -79,30 +69,24 @@ void main() {
 
   group('requestCameraAndLaunch', () {
     test(
-      'transitions to cameraDone with images when permission granted',
+      'transitions to cameraDone with path when permission granted and '
+      'camera returns a path',
       () async {
-        fakeService.mediaStoreImages = [
-          '/storage/img1.jpg',
-          '/storage/img2.jpg'
-        ];
+        fakeService.cameraReturnPath = '/storage/img1.jpg';
 
         await viewModel.requestCameraAndLaunch();
 
-        expect(
-          viewModel.state,
-          isA<CaptureEntryStateCameraDone>(),
-        );
+        expect(viewModel.state, isA<CaptureEntryStateCameraDone>());
         final done = viewModel.state as CaptureEntryStateCameraDone;
-        expect(done.imagePaths, hasLength(2));
+        expect(done.imagePaths, equals(['/storage/img1.jpg']));
         expect(fakeService.cameraLaunched, isTrue);
-        expect(fakeService.queriedTimestamp, isNotNull);
       },
     );
 
     test(
-      'transitions to cameraEmpty when no images found after camera',
+      'transitions to cameraEmpty when camera returns null (user cancelled)',
       () async {
-        fakeService.mediaStoreImages = [];
+        fakeService.cameraReturnPath = null;
 
         await viewModel.requestCameraAndLaunch();
 
@@ -138,40 +122,18 @@ void main() {
       },
     );
 
-    test('records timestamp before camera launch', () async {
-      final before = DateTime.now();
-      fakeService.mediaStoreImages = ['/storage/img.jpg'];
-
-      await viewModel.requestCameraAndLaunch();
-
-      final after = DateTime.now();
-      expect(fakeService.queriedTimestamp, isNotNull);
-      expect(
-        fakeService.queriedTimestamp!.isAfter(
-          before.subtract(const Duration(seconds: 1)),
-        ),
-        isTrue,
-      );
-      expect(
-        fakeService.queriedTimestamp!.isBefore(
-          after.add(const Duration(seconds: 1)),
-        ),
-        isTrue,
-      );
-    });
-
     test(
       'transitions to loading then resolves — notifies listeners',
       () async {
         final states = <CaptureEntryState>[];
         viewModel.addListener(() => states.add(viewModel.state));
-        fakeService.mediaStoreImages = ['/img.jpg'];
+        fakeService.cameraReturnPath = '/img.jpg';
 
         await viewModel.requestCameraAndLaunch();
 
-        // First notification must be loading
+        // First notification must be loading.
         expect(states.first, isA<CaptureEntryStateLoading>());
-        // Final notification must be cameraDone
+        // Final notification must be cameraDone.
         expect(states.last, isA<CaptureEntryStateCameraDone>());
       },
     );
@@ -188,21 +150,23 @@ void main() {
       expect(done.imagePaths, equals(['/storage/gallery1.jpg']));
     });
 
-    test('transitions to galleryDone with empty list when user cancels',
-        () async {
-      fakeService.galleryImages = [];
+    test(
+      'transitions to galleryDone with empty list when user cancels',
+      () async {
+        fakeService.galleryImages = [];
 
-      await viewModel.launchGallery();
+        await viewModel.launchGallery();
 
-      expect(viewModel.state, isA<CaptureEntryStateGalleryDone>());
-      final done = viewModel.state as CaptureEntryStateGalleryDone;
-      expect(done.imagePaths, isEmpty);
-    });
+        expect(viewModel.state, isA<CaptureEntryStateGalleryDone>());
+        final done = viewModel.state as CaptureEntryStateGalleryDone;
+        expect(done.imagePaths, isEmpty);
+      },
+    );
   });
 
   group('reset', () {
     test('returns state to idle', () async {
-      fakeService.mediaStoreImages = ['/img.jpg'];
+      fakeService.cameraReturnPath = '/img.jpg';
       await viewModel.requestCameraAndLaunch();
       expect(viewModel.state, isA<CaptureEntryStateCameraDone>());
 

--- a/test/unit/features/player/viewmodels/notation_player_view_model_auto_scroll_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_auto_scroll_test.dart
@@ -112,6 +112,14 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {
+    _prefs = _prefs.copyWith(userName: name);
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(_prefs);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_orientation_test.dart
@@ -108,6 +108,14 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {
+    _prefs = _prefs.copyWith(userName: name);
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(_prefs);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
+++ b/test/unit/features/player/viewmodels/notation_player_view_model_test.dart
@@ -114,6 +114,20 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(
+        const UserPreferences(
+          userName: 'Test',
+          themeMode: AppThemeMode.system,
+          colorSchemeMode: ColorSchemeMode.catppuccin,
+          defaultSort: SortOrder.createdAtDesc,
+          defaultView: ViewMode.list,
+        ),
+      );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/features/settings/data/preferences_repository_impl_test.dart
+++ b/test/unit/features/settings/data/preferences_repository_impl_test.dart
@@ -224,4 +224,73 @@ void main() {
       expect(prefs.tagsSeeded, isFalse);
     });
   });
+
+  group('UserPreferencesRepositoryImpl.updateUserName', () {
+    late AppDatabase db;
+    late UserPreferencesRepositoryImpl repo;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      repo = UserPreferencesRepositoryImpl(db.userPreferencesDao);
+    });
+    tearDown(() => db.close());
+
+    test('default userName is empty string', () async {
+      final prefs = await repo.getPreferences();
+      expect(prefs.userName, equals(''));
+    });
+
+    test('persists userName and reads back same value', () async {
+      await repo.updateUserName('Roudranil');
+      final prefs = await repo.getPreferences();
+      expect(prefs.userName, equals('Roudranil'));
+    });
+
+    test('overwriting with new name replaces old value', () async {
+      await repo.updateUserName('First');
+      await repo.updateUserName('Second');
+      final prefs = await repo.getPreferences();
+      expect(prefs.userName, equals('Second'));
+    });
+
+    test('does not affect other fields', () async {
+      await repo.updateThemeMode(AppThemeMode.dark);
+      await repo.updateUserName('Alice');
+      final prefs = await repo.getPreferences();
+      expect(prefs.themeMode, AppThemeMode.dark);
+      expect(prefs.userName, equals('Alice'));
+    });
+  });
+
+  group('UserPreferencesRepositoryImpl.watchPreferences', () {
+    late AppDatabase db;
+    late UserPreferencesRepositoryImpl repo;
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      repo = UserPreferencesRepositoryImpl(db.userPreferencesDao);
+    });
+    tearDown(() => db.close());
+
+    test('emits initial preferences on subscription', () async {
+      // Ensure row exists before watching.
+      await repo.getPreferences();
+      final prefs = await repo.watchPreferences().first;
+      expect(prefs.themeMode, AppThemeMode.system);
+    });
+
+    test('emits updated preferences after a write', () async {
+      // Trigger row creation.
+      await repo.getPreferences();
+
+      final stream = repo.watchPreferences();
+      final first = await stream.first;
+      expect(first.themeMode, AppThemeMode.system);
+
+      await repo.updateThemeMode(AppThemeMode.dark);
+
+      final second = await stream.first;
+      expect(second.themeMode, AppThemeMode.dark);
+    });
+  });
 }

--- a/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
+++ b/test/unit/features/settings/viewmodels/appearance_view_model_test.dart
@@ -83,6 +83,14 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateAutoScrollSpeed(double speed) async {
     _prefs = _prefs.copyWith(autoScrollSpeed: speed);
   }
+
+  @override
+  Future<void> updateUserName(String name) async {
+    _prefs = _prefs.copyWith(userName: name);
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(_prefs);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/widget/features/capture/capture_entry_sheet_test.dart
+++ b/test/widget/features/capture/capture_entry_sheet_test.dart
@@ -22,12 +22,12 @@ import 'package:swaralipi/features/capture/viewmodels/capture_entry_view_model.d
 
 class _StubCameraService implements CameraService {
   CameraPermissionStatus status;
-  List<String> mediaImages;
+  String? cameraPath;
   List<String> galleryImages;
 
   _StubCameraService({
     this.status = CameraPermissionStatus.granted,
-    this.mediaImages = const [],
+    this.cameraPath,
     this.galleryImages = const [],
   });
 
@@ -35,13 +35,7 @@ class _StubCameraService implements CameraService {
   Future<CameraPermissionStatus> requestCameraPermission() async => status;
 
   @override
-  Future<void> launchCamera() async {}
-
-  @override
-  Future<List<String>> queryMediaStoreAfterTimestamp(
-    DateTime timestamp,
-  ) async =>
-      mediaImages;
+  Future<String?> launchCamera() async => cameraPath;
 
   @override
   Future<List<String>> pickFromGallery() async => galleryImages;
@@ -84,7 +78,7 @@ void main() {
       var cameraCallCount = 0;
       final service = _StubCameraService(
         status: CameraPermissionStatus.granted,
-        mediaImages: ['/img.jpg'],
+        cameraPath: '/img.jpg',
       );
       final vm = _TrackedViewModel(service, onCamera: () => cameraCallCount++);
 

--- a/test/widget/features/library/library_screen_greeting_test.dart
+++ b/test/widget/features/library/library_screen_greeting_test.dart
@@ -1,0 +1,306 @@
+// library_screen_greeting_test.dart — widget tests for LibraryScreen greeting
+// and first-launch name prompt.
+//
+// Covers:
+//   - Shows "Hi, <name>" when preferences return a non-empty name.
+//   - Shows "Hi there" when preferencesRepository is null.
+//   - Shows the name-prompt dialog when preferences return an empty name.
+//   - Dialog Save button is disabled while the text field is empty.
+//   - Dialog Save button is enabled after text is entered.
+//   - Saving a name updates the greeting and dismisses the dialog.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:swaralipi/core/database/daos/notation_dao.dart';
+import 'package:swaralipi/features/library/screens/library_screen.dart';
+import 'package:swaralipi/features/library/viewmodels/library_view_model.dart';
+import 'package:swaralipi/shared/models/notation.dart';
+import 'package:swaralipi/shared/models/notation_detail.dart';
+import 'package:swaralipi/shared/models/notation_draft.dart';
+import 'package:swaralipi/shared/models/saved_page.dart';
+import 'package:swaralipi/shared/models/user_preferences.dart';
+import 'package:swaralipi/shared/repositories/notation_repository.dart';
+import 'package:swaralipi/shared/repositories/preferences_repository.dart';
+import 'package:swaralipi/shared/repositories/trash_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeNotationRepository implements NotationRepository {
+  @override
+  Stream<List<Notation>> watchAllActive({
+    NotationSortBy sortBy = NotationSortBy.dateDesc,
+  }) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Notation>> watchRecentlyPlayed({int limit = 5}) =>
+      const Stream.empty();
+
+  @override
+  Future<void> softDelete(String id) async {}
+
+  @override
+  Future<Notation> saveNotation(
+    NotationDraft draft,
+    List<SavedPage> pages, {
+    String? notationId,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Notation> updateNotation(String id, NotationDraft draft) =>
+      throw UnimplementedError();
+
+  @override
+  Future<NotationDetail?> loadNotation(String id) async => null;
+
+  @override
+  Future<void> updatePlayCount(String id) async {}
+
+  @override
+  Future<void> updatePageRenderParams(
+    String pageId,
+    String renderParamsJson,
+  ) async {}
+}
+
+class _FakeTrashRepository implements TrashRepository {
+  @override
+  Future<void> restoreNotation(String id) async {}
+
+  @override
+  Stream<List<Notation>> watchTrashedNotations() => const Stream.empty();
+
+  @override
+  Future<void> purgeNotation(String id) async {}
+
+  @override
+  Future<void> purgeAll() async {}
+
+  @override
+  Future<int> autoPurgeExpired() async => 0;
+}
+
+/// Fake [PreferencesRepository] that returns a configurable [UserPreferences].
+class _FakePreferencesRepository implements PreferencesRepository {
+  _FakePreferencesRepository({required this.userName});
+
+  String userName;
+  String? savedName;
+
+  @override
+  Future<UserPreferences> getPreferences() async {
+    return UserPreferences(
+      userName: userName,
+      themeMode: AppThemeMode.system,
+      colorSchemeMode: ColorSchemeMode.catppuccin,
+      defaultSort: SortOrder.createdAtDesc,
+      defaultView: ViewMode.list,
+    );
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(
+        UserPreferences(
+          userName: userName,
+          themeMode: AppThemeMode.system,
+          colorSchemeMode: ColorSchemeMode.catppuccin,
+          defaultSort: SortOrder.createdAtDesc,
+          defaultView: ViewMode.list,
+        ),
+      );
+
+  @override
+  Future<void> updateUserName(String name) async {
+    savedName = name;
+    userName = name;
+  }
+
+  @override
+  Future<void> updatePreferences(UserPreferences preferences) async {}
+
+  @override
+  Future<void> updateThemeMode(AppThemeMode mode) async {}
+
+  @override
+  Future<void> updateColorSchemeMode(ColorSchemeMode mode) async {}
+
+  @override
+  Future<void> updateSeedColor(String? colorHex) async {}
+
+  @override
+  Future<void> updatePlayerOrientation(PlayerOrientation orientation) async {}
+
+  @override
+  Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
+  Future<void> updateTagsSeeded({required bool value}) async {}
+}
+
+/// Pumps a [LibraryScreen] with a fresh [LibraryViewModel] and the given
+/// optional [preferencesRepository].
+Future<void> _pumpLibrary(
+  WidgetTester tester, {
+  _FakePreferencesRepository? preferencesRepository,
+}) async {
+  final notationRepo = _FakeNotationRepository();
+  final trashRepo = _FakeTrashRepository();
+  final vm = LibraryViewModel(notationRepo, trashRepo);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: ChangeNotifierProvider<LibraryViewModel>.value(
+        value: vm,
+        child: LibraryScreen(
+          preferencesRepository: preferencesRepository,
+        ),
+      ),
+    ),
+  );
+  // Allow postFrameCallback to run (initState → _loadGreeting).
+  await tester.pump();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('LibraryScreen greeting', () {
+    testWidgets(
+      'shows "Hi there" when preferencesRepository is null',
+      (tester) async {
+        await _pumpLibrary(tester);
+
+        expect(find.text('Hi there'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows "Hi, <name>" when preferences return a non-empty name',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: 'Roudranil');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+
+        // Wait for the async _loadGreeting to complete.
+        await tester.pump();
+
+        expect(find.text('Hi, Roudranil'), findsOneWidget);
+      },
+    );
+  });
+
+  group('LibraryScreen first-launch name prompt', () {
+    /// Pumps enough frames for the async _loadGreeting to complete and the
+    /// dialog to appear without needing pumpAndSettle (which times out because
+    /// the stream-based notation list never completes).
+    Future<void> pumpUntilDialog(WidgetTester tester) async {
+      // Allow postFrameCallback + async getPreferences + showDialog.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+    }
+
+    testWidgets(
+      'shows dialog when preferences return an empty name',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: '');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+        await pumpUntilDialog(tester);
+
+        expect(find.text("What's your name?"), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Save button is disabled while text field is empty',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: '');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+        await pumpUntilDialog(tester);
+
+        // The FilledButton should be disabled: onPressed == null.
+        final saveButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        expect(saveButton.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
+      'Save button is enabled after text is entered',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: '');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+        await pumpUntilDialog(tester);
+
+        // Target the dialog's TextField via the hint text to avoid ambiguity
+        // with the LibraryScreen search bar.
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Enter your name'),
+          'Roudranil',
+        );
+        await tester.pump();
+
+        final saveButton = tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Save'),
+        );
+        expect(saveButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'tapping Save persists the name and updates the greeting',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: '');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+        await pumpUntilDialog(tester);
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Enter your name'),
+          'Roudranil',
+        );
+        await tester.pump();
+        await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+        // pump(0): processes the tap; Navigator.pop() queues the dialog exit.
+        await tester.pump();
+        // pump(200ms): completes the dialog exit animation.
+        await tester.pump(const Duration(milliseconds: 200));
+        // pump(): allows showDialog future to complete + updateUserName await.
+        await tester.pump();
+        // pump(): allows setState + frame rebuild.
+        await tester.pump();
+
+        // Dialog should be dismissed.
+        expect(find.text("What's your name?"), findsNothing);
+
+        // Greeting should be updated.
+        expect(find.text('Hi, Roudranil'), findsOneWidget);
+
+        // Repository should have received the save call.
+        expect(repo.savedName, 'Roudranil');
+      },
+    );
+
+    testWidgets(
+      'dialog cannot be dismissed by tapping the barrier',
+      (tester) async {
+        final repo = _FakePreferencesRepository(userName: '');
+        await _pumpLibrary(tester, preferencesRepository: repo);
+        await pumpUntilDialog(tester);
+
+        // Tap outside the dialog (barrier).
+        await tester.tapAt(const Offset(10, 10));
+        await tester.pump();
+
+        // Dialog should still be present because barrierDismissible: false.
+        expect(find.text("What's your name?"), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/widget/features/player/notation_player_screen_orientation_test.dart
+++ b/test/widget/features/player/notation_player_screen_orientation_test.dart
@@ -109,6 +109,14 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() async* {
+    yield await getPreferences();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/widget/features/player/notation_player_screen_test.dart
+++ b/test/widget/features/player/notation_player_screen_test.dart
@@ -112,6 +112,20 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateTagsSeeded({required bool value}) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(
+        const UserPreferences(
+          userName: 'Test',
+          themeMode: AppThemeMode.system,
+          colorSchemeMode: ColorSchemeMode.catppuccin,
+          defaultSort: SortOrder.createdAtDesc,
+          defaultView: ViewMode.list,
+        ),
+      );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/widget/features/settings/appearance_screen_test.dart
+++ b/test/widget/features/settings/appearance_screen_test.dart
@@ -89,6 +89,14 @@ class FakePreferencesRepository implements PreferencesRepository {
   Future<void> updateAutoScrollSpeed(double speed) async {
     _prefs = _prefs.copyWith(autoScrollSpeed: speed);
   }
+
+  @override
+  Future<void> updateUserName(String name) async {
+    _prefs = _prefs.copyWith(userName: name);
+  }
+
+  @override
+  Stream<UserPreferences> watchPreferences() => Stream.value(_prefs);
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +147,12 @@ class _BlockingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() => const Stream.empty();
 }
 
 // ---------------------------------------------------------------------------
@@ -338,4 +352,10 @@ class _FailingPreferencesRepository implements PreferencesRepository {
 
   @override
   Future<void> updateAutoScrollSpeed(double speed) async {}
+
+  @override
+  Future<void> updateUserName(String name) async {}
+
+  @override
+  Stream<UserPreferences> watchPreferences() => const Stream.empty();
 }


### PR DESCRIPTION
## Linked Issues

Local task file: docs/03-implementation/tasks.md (4 tasks)

## Summary

- **Task 1 (p0):** `_openCaptureSheet` in `AppShell` now uses `showModalBottomSheet<List<String>>`, awaits the result, checks `context.mounted`, and navigates to `PageEditorScreen` with the returned paths and view-models when non-empty.
- **Task 2 (p0):** `CameraServiceImpl.launchCamera()` returns `Future<String?>` directly from `pickImage(source: ImageSource.camera)`. `requestCameraAndLaunch()` uses the path directly — no secondary gallery picker. `queryMediaStoreAfterTimestamp` removed entirely.
- **Task 3 (p1):** `user_name` DB column default changed from `'Musician'` to `''`; schema bumped to v6 with a migration that clears existing `'Musician'` rows. `LibraryScreen` shows a blocking `AlertDialog` on first launch when the stored name is empty. `_NamePromptDialog` now owns its `TextEditingController` internally (pop with `showDialog<String>`) to avoid a use-after-dispose assertion during the dialog exit animation.
- **Task 4 (p1):** `dynamic_color` added. `PreferencesRepository.watchPreferences()` and `UserPreferencesRepositoryImpl.watchPreferences()` exposed. `_SwaralipiAppState` subscribes via `StreamSubscription` + `ValueNotifier<UserPreferences?>`. `MaterialApp.router` wrapped in `DynamicColorBuilder` + `ValueListenableBuilder` — theme and themeMode rebuild on every preference change. Monet (Android 12+) applied when `colorSchemeMode == monet` and `lightDynamic != null`; falls back to `ColorScheme.fromSeed`.

## Type of Change

- [x] fix
- [x] feat

## Test Plan

- `test/unit/features/capture/capture_entry_view_model_test.dart` — camera path returned directly, no secondary gallery call
- `test/widget/features/capture/capture_entry_sheet_test.dart` — sheet renders
- `test/unit/features/settings/data/preferences_repository_impl_test.dart` — `watchPreferences` stream tests
- `test/widget/features/library/library_screen_greeting_test.dart` **(new)** — greeting default, name dialog shown, Save disabled/enabled, save persists + updates greeting, barrier not dismissible
- All 1188 tests pass; `flutter analyze` zero errors

## Checklist

- [x] All tests pass
- [x] `dart format` applied
- [x] `flutter analyze` clean (zero errors; pre-existing INFO warnings untouched)
- [x] `context.mounted` checked after every `await` touching `BuildContext`
- [x] No `print` statements
- [x] All public APIs documented with `///`